### PR TITLE
Add try_load descendant-chain spec and deep descendant lookup

### DIFF
--- a/lib/couchbase-orm.rb
+++ b/lib/couchbase-orm.rb
@@ -87,11 +87,22 @@ module CouchbaseOrm
     ddoc = result&.content&.[]('type')
     return nil unless ddoc
 
-    ::CouchbaseOrm::Base.descendants.each do |model|
-      if model.design_document == ddoc
+    models_to_visit = [::CouchbaseOrm::Base]
+    visited_models = {}
+
+    until models_to_visit.empty?
+      model = models_to_visit.shift
+      next if visited_models[model]
+
+      visited_models[model] = true
+
+      if model != ::CouchbaseOrm::Base && model.design_document == ddoc
         return model.instantiate(result.content, id, nil, model)
       end
+
+      models_to_visit.concat(Array.wrap(model.descendants)) if model.respond_to?(:descendants)
     end
+
     nil
   end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -24,6 +24,17 @@ class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
   attribute :job, :string
 end
 
+class ApplicationRecord < CouchbaseOrm::Base
+end
+
+class EventBase < ApplicationRecord
+  attribute :name, :string
+end
+
+class SendSmsEvent < EventBase
+  attribute :phone_number, :string
+end
+
 describe CouchbaseOrm::Base do
   it 'is comparable to other objects' do
     base = BaseTest.create!(name: 'joe')
@@ -151,6 +162,18 @@ describe CouchbaseOrm::Base do
     expect(obj).to eq(base)
   ensure
     base.destroy
+  end
+
+  it 'tries to load with descendant chain ApplicationRecord -> EventBase -> SendSmsEvent' do
+    event = SendSmsEvent.create!(name: 'sms', phone_number: '+15551234567')
+    loaded = CouchbaseOrm.try_load(event.id)
+
+    expect(loaded).to be_a(SendSmsEvent)
+    expect(loaded.id).to eq(event.id)
+    expect(loaded.name).to eq('sms')
+    expect(loaded.phone_number).to eq('+15551234567')
+  ensure
+    event&.destroy
   end
 
   it 'is able to create model with a custom ID' do


### PR DESCRIPTION
This change fixes model resolution in try_load when the target model is not a direct child of CouchbaseOrm::Base.
It also adds a regression test for a 3-level inheritance chain: ApplicationRecord -> EventBase -> SendSmsEvent.