### PR TITLE
add build deferred index

### DIFF
--- a/docs/reference/index-migrations.txt
+++ b/docs/reference/index-migrations.txt
@@ -26,7 +26,6 @@ Configure index migration options with ``CouchbaseOrm.configure``:
   CouchbaseOrm.configure do |config|
     config.index.bucket = 'fleet-prod'
     config.index.num_replica = 1
-    config.index.defer_build = true
   end
 
 Supported options:
@@ -45,10 +44,6 @@ Supported options:
 
    * - ``num_replica``
      - ``0``
-     - Value used in the index ``WITH`` clause.
-
-   * - ``defer_build``
-     - ``true``
      - Value used in the index ``WITH`` clause.
 
 Migration files are loaded from ``db/indexes`` by default.
@@ -87,7 +82,8 @@ DSL
   add_index(
     :type_company,
     keys: [:type, :company_id],
-    where: 'type is valued and company_id is valued'
+    where: 'type is valued and company_id is valued',
+    defer_build: true
   )
 
 Example generated query:

--- a/lib/couchbase-orm/configuration.rb
+++ b/lib/couchbase-orm/configuration.rb
@@ -3,12 +3,11 @@
 module CouchbaseOrm
   class Configuration
     class Index
-      attr_accessor :bucket, :num_replica, :defer_build, :migrations_path
+      attr_accessor :bucket, :num_replica, :migrations_path
 
       def initialize
         @bucket = nil
         @num_replica = 0
-        @defer_build = true
         @migrations_path = 'db/indexes'
       end
 

--- a/lib/couchbase-orm/index_migration.rb
+++ b/lib/couchbase-orm/index_migration.rb
@@ -9,20 +9,38 @@ module CouchbaseOrm
 
     module Operations
       class AddIndex
-        attr_reader :name, :keys, :where
+        attr_reader :name, :keys, :where, :defer_build
 
-        def initialize(name, keys:, where: nil)
+        def initialize(name, keys:, where: nil, defer_build: false)
           @name = name
           @keys = keys
           @where = where
+          @defer_build = defer_build
         end
 
         def execute(migration)
-          migration.execute_add_index(name, keys: keys, where: where)
+          migration.execute_add_index(name, keys: keys, where: where, defer_build: defer_build)
         end
 
         def inverse
           RemoveIndex.new(name)
+        end
+      end
+
+      class BuildIndexes
+        attr_reader :index_names
+
+        def initialize(index_names)
+          @index_names = Array(index_names).flatten
+          raise ArgumentError.new('At least one index name is required') if @index_names.empty?
+        end
+
+        def execute(migration)
+          migration.execute_build_indexes(index_names)
+        end
+
+        def inverse
+          raise IrreversibleMigration.new('build_indexes is not reversible. Define down explicitly.')
         end
       end
 
@@ -64,7 +82,7 @@ module CouchbaseOrm
         @config = config
       end
 
-      def add_index(name, keys:, where: nil)
+      def add_index(name, keys:, where: nil, defer_build: false)
         bucket = @config.effective_bucket
         raise ArgumentError.new('Missing index bucket configuration') if bucket.to_s.strip.empty?
         raise ArgumentError.new('Missing index keys configuration') if Array(keys).empty?
@@ -72,8 +90,20 @@ module CouchbaseOrm
         query = +"CREATE INDEX `#{name}`\n"
         query << "ON `#{bucket}`(#{Array(keys).map { |key| "`#{key}`" }.join(',')})"
         query << "\nWHERE (#{where})" if where
-        query << "\nWITH #{JSON.pretty_generate(with_options)}"
+        options = with_options(defer_build: defer_build)
+        query << "\nWITH #{JSON.pretty_generate(options)}" unless options.empty?
         query
+      end
+
+      def build_indexes(index_names)
+        bucket = @config.effective_bucket
+        raise ArgumentError.new('Missing index bucket configuration') if bucket.to_s.strip.empty?
+
+        names = Array(index_names)
+        raise ArgumentError.new('At least one index name is required') if names.empty?
+
+        index_lines = names.map { |name| "  `#{name}`" }.join(",\n")
+        "BUILD INDEX ON `#{bucket}`\n(\n#{index_lines}\n);"
       end
 
       def remove_index(name)
@@ -85,11 +115,11 @@ module CouchbaseOrm
 
       private
 
-      def with_options
-        {
-          'defer_build' => @config.defer_build,
-          'num_replica' => @config.num_replica
-        }
+      def with_options(defer_build:)
+        options = {}
+        options['defer_build'] = true if defer_build
+        options['num_replica'] = @config.num_replica unless @config.num_replica.nil?
+        options
       end
     end
 
@@ -104,20 +134,28 @@ module CouchbaseOrm
       end
     end
 
-    def add_index(name, keys:, where: nil)
-      execute_operation(Operations::AddIndex.new(name, keys: keys, where: where))
+    def add_index(name, keys:, where: nil, defer_build: false)
+      execute_operation(Operations::AddIndex.new(name, keys: keys, where: where, defer_build: defer_build))
     end
 
     def remove_index(name)
       execute_operation(Operations::RemoveIndex.new(name))
     end
 
-    def execute_add_index(name, keys:, where: nil)
-      execute_query(query_builder.add_index(name, keys: keys, where: where))
+    def build_indexes(*index_names)
+      execute_operation(Operations::BuildIndexes.new(index_names))
+    end
+
+    def execute_add_index(name, keys:, where: nil, defer_build: false)
+      execute_query(query_builder.add_index(name, keys: keys, where: where, defer_build: defer_build))
     end
 
     def execute_remove_index(name)
       execute_query(query_builder.remove_index(name))
+    end
+
+    def execute_build_indexes(index_names)
+      execute_query(query_builder.build_indexes(index_names))
     end
 
     private

--- a/spec/index_migration_spec.rb
+++ b/spec/index_migration_spec.rb
@@ -8,12 +8,11 @@ describe CouchbaseOrm::IndexMigration do
     CouchbaseOrm.configure do |config|
       config.index.bucket = 'fleet-prod'
       config.index.num_replica = 1
-      config.index.defer_build = true
     end
   end
 
   describe CouchbaseOrm::IndexMigration::QueryBuilder do
-    it 'builds create index query with where clause and options' do
+    it 'builds create index query without deferred build option by default' do
       query = described_class.new.add_index(
         :type_company,
         keys: %i[type company_id],
@@ -25,9 +24,39 @@ describe CouchbaseOrm::IndexMigration do
         ON `fleet-prod`(`type`,`company_id`)
         WHERE (type is valued and company_id is valued)
         WITH {
+          "num_replica": 1
+        }
+      SQL
+    end
+
+    it 'builds create index query with deferred build option' do
+      query = described_class.new.add_index(
+        :type_company,
+        keys: %i[type company_id],
+        where: 'type is valued and company_id is valued',
+        defer_build: true
+      )
+
+      expect(query).to eq(<<~SQL.strip)
+        CREATE INDEX `type_company`
+        ON `fleet-prod`(`type`,`company_id`)
+        WHERE (type is valued and company_id is valued)
+        WITH {
           "defer_build": true,
           "num_replica": 1
         }
+      SQL
+    end
+
+    it 'builds build indexes query' do
+      query = described_class.new.build_indexes(%i[type_company date_on_type])
+
+      expect(query).to eq(<<~SQL.strip)
+        BUILD INDEX ON `fleet-prod`
+        (
+          `type_company`,
+          `date_on_type`
+        );
       SQL
     end
 
@@ -58,6 +87,49 @@ describe CouchbaseOrm::IndexMigration do
     migration_class = Class.new(CouchbaseOrm::IndexMigration) do
       def change
         remove_index :legacy_index
+      end
+    end
+
+    expect { migration_class.new.migrate(:down) }
+      .to raise_error(CouchbaseOrm::IndexMigration::IrreversibleMigration)
+  end
+
+  it 'executes deferred indexes then explicit build in order' do
+    migration_class = Class.new(CouchbaseOrm::IndexMigration) do
+      def up
+        add_index :type_company, keys: %i[type company_id], where: 'type is valued and company_id is valued', defer_build: true
+        add_index :date_on_type, keys: [:date], where: 'type is valued and date is valued', defer_build: true
+        build_indexes :type_company, :date_on_type
+      end
+    end
+
+    cluster = instance_double(Couchbase::Cluster)
+    allow(CouchbaseOrm::Connection).to receive(:cluster).and_return(cluster)
+
+    expect(cluster).to receive(:query).with(/CREATE INDEX `type_company`[\s\S]*"defer_build": true/, instance_of(Couchbase::Options::Query)).ordered
+    expect(cluster).to receive(:query).with(/CREATE INDEX `date_on_type`[\s\S]*"defer_build": true/, instance_of(Couchbase::Options::Query)).ordered
+    expect(cluster).to receive(:query).with(<<~SQL.strip, instance_of(Couchbase::Options::Query)).ordered
+      BUILD INDEX ON `fleet-prod`
+      (
+        `type_company`,
+        `date_on_type`
+      );
+    SQL
+
+    migration_class.new.migrate(:up)
+  end
+
+  it 'raises argument error when build_indexes receives no names' do
+    migration_class = Class.new(described_class)
+
+    expect { migration_class.new.build_indexes }
+      .to raise_error(ArgumentError, /At least one index name is required/)
+  end
+
+  it 'raises irreversible migration when build_indexes is used in change' do
+    migration_class = Class.new(CouchbaseOrm::IndexMigration) do
+      def change
+        build_indexes :type_company
       end
     end
 

--- a/specs/001-add-index-migration/plan.md
+++ b/specs/001-add-index-migration/plan.md
@@ -69,7 +69,6 @@ Use configuration:
 ```ruby
 config.index.bucket
 config.index.num_replica
-config.index.defer_build
 ```
 
 ---

--- a/specs/001-add-index-migration/spec.md
+++ b/specs/001-add-index-migration/spec.md
@@ -43,7 +43,6 @@ Users are expected to explicitly create migrations describing changes.
 CouchbaseOrm.configure do |config|
   config.index.bucket = "fleet-prod"
   config.index.num_replica = 1
-  config.index.defer_build = true
 end
 ```
 
@@ -53,8 +52,6 @@ Supported settings:
 | ----------- | -------- |
 | bucket      | required |
 | num_replica | 0        |
-| defer_build | true     |
-
 These values are automatically applied to every index created by migrations.
 
 ---

--- a/specs/002-add-build-index-support/plan.md
+++ b/specs/002-add-build-index-support/plan.md
@@ -1,0 +1,431 @@
+# Implementation Plan: Deferred Index Build Support
+
+## Goal
+
+Support deferred index creation and explicit `BUILD INDEX` operations while keeping the API simple and close to ActiveRecord.
+
+Example:
+
+```ruby
+class InitialIndexes < CouchbaseOrm::IndexMigration
+  def up
+    add_index(
+      :type_company,
+      keys: [:type, :company_id],
+      where: "type is valued and company_id is valued",
+      defer_build: true
+    )
+
+    add_index(
+      :date_on_type,
+      keys: [:date],
+      where: "type is valued and date is valued",
+      defer_build: true
+    )
+
+    build_indexes(
+      :type_company,
+      :date_on_type
+    )
+  end
+
+  def down
+    remove_index :date_on_type
+    remove_index :type_company
+  end
+end
+```
+
+---
+
+# Phase 1 — Extend AddIndex
+
+## Goal
+
+Allow indexes to be created with `defer_build: true`.
+
+## Tasks
+
+### Add option
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type, :company_id],
+  defer_build: true
+)
+```
+
+### Extend AddIndex operation
+
+```ruby
+CouchbaseOrm::IndexMigration::Operations::AddIndex
+```
+
+with:
+
+```ruby
+name
+keys
+where
+defer_build
+```
+
+### Update QueryBuilder
+
+Current:
+
+```sql
+CREATE INDEX ...
+```
+
+New:
+
+```sql
+CREATE INDEX ...
+WITH {
+  "defer_build": true,
+  "num_replica": 1
+}
+```
+
+when:
+
+```ruby
+defer_build == true
+```
+
+Otherwise:
+
+```sql
+CREATE INDEX ...
+```
+
+or:
+
+```sql
+WITH {
+  "num_replica": 1
+}
+```
+
+depending on current implementation.
+
+---
+
+# Phase 2 — BuildIndexes Operation
+
+## Goal
+
+Introduce explicit BUILD INDEX support.
+
+## Create operation
+
+```ruby
+CouchbaseOrm::IndexMigration::Operations::BuildIndexes
+```
+
+Attributes:
+
+```ruby
+index_names
+```
+
+Example:
+
+```ruby
+BuildIndexes.new(
+  [:type_company, :date_on_type]
+)
+```
+
+---
+
+## Validation
+
+Raise:
+
+```ruby
+ArgumentError
+```
+
+when:
+
+```ruby
+build_indexes()
+```
+
+receives no index names.
+
+---
+
+# Phase 3 — Query Builder
+
+## Goal
+
+Generate BUILD INDEX statements.
+
+Input:
+
+```ruby
+BuildIndexes.new(
+  [:type_company, :date_on_type]
+)
+```
+
+Output:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+Bucket comes from:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+```
+
+---
+
+# Phase 4 — DSL
+
+## Goal
+
+Expose the command in migrations.
+
+Add:
+
+```ruby
+build_indexes(*index_names)
+```
+
+Example:
+
+```ruby
+build_indexes(
+  :type_company,
+  :date_on_type
+)
+```
+
+Internally:
+
+```ruby
+record(
+  Operations::BuildIndexes.new(index_names)
+)
+```
+
+---
+
+# Phase 5 — Command Recorder
+
+## Goal
+
+Support rollback behavior.
+
+Since:
+
+```sql
+BUILD INDEX
+```
+
+cannot be reversed,
+
+register:
+
+```ruby
+build_indexes
+```
+
+as irreversible.
+
+Rollback of:
+
+```ruby
+def change
+  build_indexes :type_company
+end
+```
+
+raises:
+
+```ruby
+CouchbaseOrm::IrreversibleMigration
+```
+
+similar to:
+
+```ruby
+execute(...)
+```
+
+in ActiveRecord.
+
+---
+
+# Phase 6 — Execution
+
+## Goal
+
+Execute BUILD INDEX queries.
+
+Example migration:
+
+```ruby
+def up
+  add_index(
+    :type_company,
+    keys: [:type, :company_id],
+    defer_build: true
+  )
+
+  add_index(
+    :date_on_type,
+    keys: [:date],
+    defer_build: true
+  )
+
+  build_indexes(
+    :type_company,
+    :date_on_type
+  )
+end
+```
+
+Execution order:
+
+```sql
+CREATE INDEX ...
+
+CREATE INDEX ...
+
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+---
+
+# Phase 7 — Tests
+
+## AddIndex
+
+### immediate index
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type]
+)
+```
+
+does not generate:
+
+```json
+{
+  "defer_build": true
+}
+```
+
+---
+
+### deferred index
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type],
+  defer_build: true
+)
+```
+
+generates:
+
+```json
+{
+  "defer_build": true
+}
+```
+
+---
+
+## BuildIndexes
+
+Input:
+
+```ruby
+build_indexes(
+  :type_company,
+  :date_on_type
+)
+```
+
+Output:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+---
+
+## Empty build
+
+```ruby
+build_indexes()
+```
+
+raises:
+
+```ruby
+ArgumentError
+```
+
+---
+
+## Reversibility
+
+Migration:
+
+```ruby
+def change
+  build_indexes :type_company
+end
+```
+
+Rollback raises:
+
+```ruby
+CouchbaseOrm::IrreversibleMigration
+```
+
+---
+
+# V1 Complete
+
+Supported:
+
+* `add_index(..., defer_build: true)`
+* `build_indexes(*names)`
+* rollback protection
+
+Not supported:
+
+* automatic build detection
+* build progress monitoring
+* waiting for indexes to become online
+* querying `system:indexes`
+* build all deferred indexes
+* grouped builds across migrations
+
+The design intentionally favors simplicity and explicit behavior, following the philosophy of ActiveRecord migrations.

--- a/specs/002-add-build-index-support/spec.md
+++ b/specs/002-add-build-index-support/spec.md
@@ -1,0 +1,207 @@
+# Spec: Deferred Index Build Support
+
+## Motivation
+
+Couchbase supports deferred index creation:
+
+```sql
+CREATE INDEX ...
+WITH { "defer_build": true }
+```
+
+followed by:
+
+```sql
+BUILD INDEX ON `bucket`(...);
+```
+
+CouchbaseORM should provide a simple and explicit way to perform these operations.
+
+---
+
+# Goals
+
+* Support deferred indexes.
+* Support explicit BUILD INDEX operations.
+* Avoid hidden behavior.
+* Stay close to ActiveRecord.
+
+---
+
+# DSL
+
+## add_index
+
+Immediate index:
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type, :company_id],
+  where: "type is valued and company_id is valued"
+)
+```
+
+Generates:
+
+```sql
+CREATE INDEX ...
+```
+
+---
+
+Deferred index:
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type, :company_id],
+  where: "type is valued and company_id is valued",
+  defer_build: true
+)
+```
+
+Generates:
+
+```sql
+CREATE INDEX ...
+WITH {
+  "defer_build": true,
+  "num_replica": 1
+}
+```
+
+---
+
+## build_indexes
+
+```ruby
+build_indexes :type_company, :date_on_type
+```
+
+Generates:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+---
+
+# Example
+
+```ruby
+class InitialIndexes < CouchbaseOrm::IndexMigration
+  def change
+    add_index(
+      :type_company,
+      keys: [:type, :company_id],
+      defer_build: true
+    )
+
+    add_index(
+      :date_on_type,
+      keys: [:date],
+      defer_build: true
+    )
+
+    build_indexes(
+      :type_company,
+      :date_on_type
+    )
+  end
+end
+```
+
+Execution:
+
+```sql
+CREATE INDEX `type_company`
+...
+WITH { "defer_build": true, "num_replica": 1 };
+
+CREATE INDEX `date_on_type`
+...
+WITH { "defer_build": true, "num_replica": 1 };
+
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+---
+
+# Reversibility
+
+`add_index(..., defer_build: true)` is reversible.
+
+Rollback executes:
+
+```sql
+DROP INDEX ...
+```
+
+`build_indexes` is irreversible.
+
+Therefore:
+
+```ruby
+def change
+  build_indexes :type_company
+end
+```
+
+raises:
+
+```ruby
+CouchbaseOrm::IrreversibleMigration
+```
+
+during rollback.
+
+Complex migrations requiring `build_indexes` should use:
+
+```ruby
+def up
+end
+
+def down
+end
+```
+
+---
+
+# Acceptance Criteria
+
+Given:
+
+```ruby
+add_index :type_company,
+  keys: [:type, :company_id],
+  defer_build: true
+
+add_index :date_on_type,
+  keys: [:date],
+  defer_build: true
+
+build_indexes :type_company, :date_on_type
+```
+
+Then:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+is executed.
+
+No internal tracking of deferred indexes is performed.


### PR DESCRIPTION
# Implementation Plan: Deferred Index Build Support

## Goal

Support deferred index creation and explicit `BUILD INDEX` operations while keeping the API simple and close to ActiveRecord.

Example:

```ruby
class InitialIndexes < CouchbaseOrm::IndexMigration
  def up
    add_index(
      :type_company,
      keys: [:type, :company_id],
      where: "type is valued and company_id is valued",
      defer_build: true
    )

    add_index(
      :date_on_type,
      keys: [:date],
      where: "type is valued and date is valued",
      defer_build: true
    )

    build_indexes(
      :type_company,
      :date_on_type
    )
  end

  def down
    remove_index :date_on_type
    remove_index :type_company
  end
end
```

---

# Phase 1 — Extend AddIndex

## Goal

Allow indexes to be created with `defer_build: true`.

## Tasks

### Add option

```ruby
add_index(
  :type_company,
  keys: [:type, :company_id],
  defer_build: true
)
```

### Extend AddIndex operation

```ruby
CouchbaseOrm::IndexMigration::Operations::AddIndex
```

with:

```ruby
name
keys
where
defer_build
```

### Update QueryBuilder

Current:

```sql
CREATE INDEX ...
```

New:

```sql
CREATE INDEX ...
WITH {
  "defer_build": true,
  "num_replica": 1
}
```

when:

```ruby
defer_build == true
```

Otherwise:

```sql
CREATE INDEX ...
```

or:

```sql
WITH {
  "num_replica": 1
}
```

depending on current implementation.

---

# Phase 2 — BuildIndexes Operation

## Goal

Introduce explicit BUILD INDEX support.

## Create operation

```ruby
CouchbaseOrm::IndexMigration::Operations::BuildIndexes
```

Attributes:

```ruby
index_names
```

Example:

```ruby
BuildIndexes.new(
  [:type_company, :date_on_type]
)
```

---

## Validation

Raise:

```ruby
ArgumentError
```

when:

```ruby
build_indexes()
```

receives no index names.

---

# Phase 3 — Query Builder

## Goal

Generate BUILD INDEX statements.

Input:

```ruby
BuildIndexes.new(
  [:type_company, :date_on_type]
)
```

Output:

```sql
BUILD INDEX ON `bucket`
(
  `type_company`,
  `date_on_type`
);
```

Bucket comes from:

```ruby
CouchbaseOrm.config.index.bucket
```

---

# Phase 4 — DSL

## Goal

Expose the command in migrations.

Add:

```ruby
build_indexes(*index_names)
```

Example:

```ruby
build_indexes(
  :type_company,
  :date_on_type
)
```

Internally:

```ruby
record(
  Operations::BuildIndexes.new(index_names)
)
```

---

# Phase 5 — Command Recorder

## Goal

Support rollback behavior.

Since:

```sql
BUILD INDEX
```

cannot be reversed,

register:

```ruby
build_indexes
```

as irreversible.

Rollback of:

```ruby
def change
  build_indexes :type_company
end
```

raises:

```ruby
CouchbaseOrm::IrreversibleMigration
```

similar to:

```ruby
execute(...)
```

in ActiveRecord.

---

# Phase 6 — Execution

## Goal

Execute BUILD INDEX queries.

Example migration:

```ruby
def up
  add_index(
    :type_company,
    keys: [:type, :company_id],
    defer_build: true
  )

  add_index(
    :date_on_type,
    keys: [:date],
    defer_build: true
  )

  build_indexes(
    :type_company,
    :date_on_type
  )
end
```

Execution order:

```sql
CREATE INDEX ...

CREATE INDEX ...

BUILD INDEX ON `bucket`
(
  `type_company`,
  `date_on_type`
);
```

---

# Phase 7 — Tests

## AddIndex

### immediate index

```ruby
add_index(
  :type_company,
  keys: [:type]
)
```

does not generate:

```json
{
  "defer_build": true
}
```

---

### deferred index

```ruby
add_index(
  :type_company,
  keys: [:type],
  defer_build: true
)
```

generates:

```json
{
  "defer_build": true
}
```

---

## BuildIndexes

Input:

```ruby
build_indexes(
  :type_company,
  :date_on_type
)
```

Output:

```sql
BUILD INDEX ON `bucket`
(
  `type_company`,
  `date_on_type`
);
```

---

## Empty build

```ruby
build_indexes()
```

raises:

```ruby
ArgumentError
```

---

## Reversibility

Migration:

```ruby
def change
  build_indexes :type_company
end
```

Rollback raises:

```ruby
CouchbaseOrm::IrreversibleMigration
```

---

# V1 Complete

Supported:

* `add_index(..., defer_build: true)`
* `build_indexes(*names)`
* rollback protection

Not supported:

* automatic build detection
* build progress monitoring
* waiting for indexes to become online
* querying `system:indexes`
* build all deferred indexes
* grouped builds across migrations

The design intentionally favors simplicity and explicit behavior, following the philosophy of ActiveRecord migrations.
