### PR TITLE
Add index config for rails

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -27,6 +27,9 @@ named "dev_bucket".
     development:
       <<: *common
       bucket: dev_bucket
+      index:
+        migrations_path: db/indexes
+        num_replica: 0
 
     test:
       <<: *common
@@ -38,10 +41,20 @@ named "dev_bucket".
       bucket: <%= ENV['COUCHBASE_BUCKET'] %>
       username: <%= ENV['COUCHBASE_USER'] %>
       password: <%= ENV['COUCHBASE_PASSWORD'] %>
+      index:
+        bucket: <%= ENV['COUCHBASE_INDEX_BUCKET'] %>
+        num_replica: 1
 
 The top level key in the configuration file, ``development`` in the above
 example, refers to the environment name which the application is executing in,
 i.e. ``development``, ``test`` or ``production``.
+
+Index migration settings for Rails applications may also be configured in the
+nested ``index`` section. Supported keys are ``bucket``, ``migrations_path``
+and ``num_replica``.
+
+When ``index.bucket`` is omitted, CouchbaseOrm uses the top-level connection
+``bucket`` as the default index bucket.
 
 Generating Default Configuration
 ================================
@@ -53,12 +66,13 @@ configuration file for you by running the following command:
 
   rails g couchbase_orm:config
 
-The configuration file will be placed in ``config/couchbase.yml``. An
-It is recommended that all configuration
+The configuration file will be placed in ``config/couchbase.yml``. It
+is recommended that all configuration
 be specified in ``config/couchbase.yml``, but if you prefer, the ``couchbase_orm.rb``
 initializer may also be used to set configuration options. Note, though, that
-settings in ``couchbase.yml`` always take precedence over settings in the
-initializer.
+settings loaded from ``couchbase.yml`` during Rails initialization take
+precedence over values set earlier in an initializer. Later explicit
+``CouchbaseOrm.configure`` calls still override those loaded values at runtime.
 
 If you are not using Rails, you can configure couchbase-orm with an initializer:
 
@@ -79,6 +93,9 @@ Loading CouchbaseOrm Configuration
 If you are using Ruby on Rails, CouchbaseOrm configuration is automatically loaded
 for the current environment as stored in ``Rails.env`` when the application
 loads.
+
+For index migrations, Rails loads the same ``config/couchbase.yml`` entry and
+applies nested ``index`` values after connection settings are loaded.
 
 ERb Preprocessing
 =================

--- a/docs/reference/index-migrations.txt
+++ b/docs/reference/index-migrations.txt
@@ -19,12 +19,32 @@ definition history in your application code.
 Configuration
 =============
 
-Configure index migration options with ``CouchbaseOrm.configure``:
+Rails applications can configure index migration options in
+``config/couchbase.yml`` using a nested ``index`` section:
+
+.. code-block:: yaml
+
+  development:
+    connection_string: couchbase://localhost
+    username: dev_user
+    password: dev_password
+    bucket: fleet-dev
+
+    index:
+      migrations_path: custom/indexes
+      num_replica: 1
+
+The index bucket defaults to the top-level ``bucket`` unless ``index.bucket``
+is set explicitly.
+
+You can also configure or override index migration options in Ruby with
+``CouchbaseOrm.configure``:
 
 .. code-block:: ruby
 
   CouchbaseOrm.configure do |config|
     config.index.bucket = 'fleet-prod'
+    config.index.migrations_path = 'db/indexes'
     config.index.num_replica = 1
   end
 
@@ -39,14 +59,23 @@ Supported options:
      - Description
 
    * - ``bucket``
-     - required
+     - top-level connection bucket in Rails, otherwise ``nil``
      - Bucket used in generated ``CREATE INDEX`` and ``DROP INDEX`` statements.
+
+   * - ``migrations_path``
+     - ``db/indexes``
+     - Directory used to load and generate index migration files.
 
    * - ``num_replica``
      - ``0``
      - Value used in the index ``WITH`` clause.
 
-Migration files are loaded from ``db/indexes`` by default.
+In Rails, values are applied in this order:
+
+1. Default index configuration values.
+2. The top-level connection ``bucket`` from ``config/couchbase.yml``.
+3. Nested ``index`` values from ``config/couchbase.yml``.
+4. Later explicit ``CouchbaseOrm.configure`` calls.
 
 Creating Migrations
 ===================

--- a/lib/couchbase-orm/index_config_loader.rb
+++ b/lib/couchbase-orm/index_config_loader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/hash/indifferent_access'
+
+module CouchbaseOrm
+  class IndexConfigLoader
+    SUPPORTED_KEYS = %i[bucket migrations_path num_replica].freeze
+
+    def self.apply(config_hash)
+      config_hash = config_hash.with_indifferent_access
+      index_hash = (config_hash[:index] || {}).with_indifferent_access
+
+      index_config = {
+        bucket: config_hash[:bucket]
+      }.merge(index_hash.slice(*SUPPORTED_KEYS))
+
+      index_config.each do |key, value|
+        CouchbaseOrm.config.index.public_send("#{key}=", value)
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/railtie.rb
+++ b/lib/couchbase-orm/railtie.rb
@@ -20,6 +20,7 @@
 
 require 'yaml'
 require 'couchbase-orm/base'
+require 'couchbase-orm/index_config_loader'
 
 module Rails # :nodoc:
   module Couchbase # :nodoc:
@@ -44,6 +45,11 @@ module Rails # :nodoc:
 
       initializer 'couchbase_orm.setup_connection_config' do
         CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
+      end
+
+      initializer 'couchbase_orm.setup_index_config', after: 'couchbase_orm.setup_connection_config' do
+        config_hash = Rails.application.config_for(:couchbase)
+        CouchbaseOrm::IndexConfigLoader.apply(config_hash)
       end
 
         # After initialization we will warn the user if we can't find a couchbase.yml and

--- a/spec/index_config_loader_spec.rb
+++ b/spec/index_config_loader_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+require 'couchbase-orm/index_config_loader'
+
+describe CouchbaseOrm::IndexConfigLoader do
+  before do
+    CouchbaseOrm.reset_config!
+  end
+
+  it 'loads migrations_path from nested index config' do
+    described_class.apply(
+      bucket: 'fleet-dev',
+      index: {
+        migrations_path: 'custom/indexes'
+      }
+    )
+
+    expect(CouchbaseOrm.config.index.migrations_path).to eq('custom/indexes')
+  end
+
+  it 'loads num_replica from nested index config' do
+    described_class.apply(
+      bucket: 'fleet-dev',
+      index: {
+        num_replica: 1
+      }
+    )
+
+    expect(CouchbaseOrm.config.index.num_replica).to eq(1)
+  end
+
+  it 'defaults index bucket to connection bucket from top-level config' do
+    described_class.apply(bucket: 'fleet-dev')
+
+    expect(CouchbaseOrm.config.index.bucket).to eq('fleet-dev')
+  end
+
+  it 'allows explicit index bucket override' do
+    described_class.apply(
+      bucket: 'fleet-dev',
+      index: {
+        bucket: 'fleet-indexes'
+      }
+    )
+
+    expect(CouchbaseOrm.config.index.bucket).to eq('fleet-indexes')
+  end
+
+  it 'preserves index defaults when values are absent' do
+    described_class.apply(bucket: 'fleet-dev')
+
+    expect(CouchbaseOrm.config.index.migrations_path).to eq('db/indexes')
+    expect(CouchbaseOrm.config.index.num_replica).to eq(0)
+  end
+
+  it 'ignores unknown keys under index' do
+    expect do
+      described_class.apply(
+        bucket: 'fleet-dev',
+        index: {
+          foo: 'bar'
+        }
+      )
+    end.not_to raise_error
+
+    expect(CouchbaseOrm.config.index.respond_to?(:foo)).to be(false)
+  end
+
+  it 'supports runtime override after loading yaml values' do
+    described_class.apply(
+      bucket: 'fleet-dev',
+      index: {
+        num_replica: 1
+      }
+    )
+
+    CouchbaseOrm.configure do |config|
+      config.index.num_replica = 2
+    end
+
+    expect(CouchbaseOrm.config.index.num_replica).to eq(2)
+  end
+end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+
+describe 'CouchbaseOrm Railtie' do # rubocop:disable RSpec/DescribeClass
+  it 'registers index config initializer after connection config initializer' do
+    railtie_source = File.read(File.expand_path('../lib/couchbase-orm/railtie.rb', __dir__))
+
+    expect(railtie_source).to include(
+      "initializer 'couchbase_orm.setup_index_config', after: 'couchbase_orm.setup_connection_config'"
+    )
+  end
+end

--- a/specs/003-add-index-config-for-rails/plan.md
+++ b/specs/003-add-index-config-for-rails/plan.md
@@ -1,0 +1,345 @@
+# Implementation Plan: Rails Index Migration Configuration
+
+## Goal
+
+Allow Rails applications to configure index migration settings from
+`config/couchbase.yml`, using the same loading model as connection settings.
+
+The index bucket should default to the connection bucket unless explicitly overridden.
+
+---
+
+# Phase 1 — Configuration Merge
+
+## Goal
+
+Define the final configuration precedence.
+
+### Precedence
+
+1. Defaults from `CouchbaseOrm::Configuration::Index`.
+2. Connection bucket from `config/couchbase.yml`.
+3. Nested `index` section values.
+4. Later explicit `CouchbaseOrm.configure` calls.
+
+Example:
+
+```yaml
+development:
+  bucket: fleet-dev
+
+  index:
+    num_replica: 1
+```
+
+Result:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-dev"
+
+CouchbaseOrm.config.index.num_replica
+# => 1
+```
+
+---
+
+# Phase 2 — Add Railtie Initializer
+
+## Goal
+
+Load index configuration after connection configuration.
+
+Current:
+
+```ruby
+initializer 'couchbase_orm.setup_connection_config' do
+  CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
+end
+```
+
+Add:
+
+```ruby
+initializer 'couchbase_orm.setup_index_config',
+            after: 'couchbase_orm.setup_connection_config'
+```
+
+This guarantees connection configuration is already available.
+
+---
+
+# Phase 3 — Load YAML Configuration
+
+## Goal
+
+Reuse the same configuration source.
+
+Load:
+
+```ruby
+config_hash =
+  Rails.application
+       .config_for(:couchbase)
+       .with_indifferent_access
+```
+
+Extract:
+
+```ruby
+index_hash =
+  (config_hash[:index] || {})
+    .with_indifferent_access
+```
+
+---
+
+# Phase 4 — Merge Connection Bucket
+
+## Goal
+
+Default index bucket to the application bucket.
+
+Build:
+
+```ruby
+index_config = {
+  bucket: config_hash[:bucket]
+}.merge(
+  index_hash.slice(
+    :bucket,
+    :migrations_path,
+    :num_replica
+  )
+)
+```
+
+Behavior:
+
+Connection bucket:
+
+```yaml
+bucket: fleet-prod
+```
+
+becomes:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-prod"
+```
+
+unless:
+
+```yaml
+index:
+  bucket: fleet-indexes
+```
+
+is present.
+
+---
+
+# Phase 5 — Apply Configuration
+
+## Goal
+
+Populate `CouchbaseOrm.config.index`.
+
+For each value:
+
+```ruby
+index_config.each do |key, value|
+  CouchbaseOrm.config.index.public_send("#{key}=", value)
+end
+```
+
+Only keys present in the merged configuration are applied.
+
+Unknown YAML keys are ignored.
+
+---
+
+# Phase 6 — Preserve Defaults
+
+## Goal
+
+Allow defaults to remain when values are absent.
+
+Defaults:
+
+```ruby
+migrations_path = "db/indexes"
+bucket = nil
+num_replica = 0
+```
+
+Example:
+
+```yaml
+development:
+  bucket: fleet-dev
+```
+
+Result:
+
+```ruby
+bucket = "fleet-dev"
+migrations_path = "db/indexes"
+num_replica = 0
+```
+
+---
+
+# Phase 7 — Tests
+
+## Loads migrations_path
+
+Given:
+
+```yaml
+index:
+  migrations_path: custom/indexes
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.migrations_path
+# => "custom/indexes"
+```
+
+---
+
+## Loads num_replica
+
+Given:
+
+```yaml
+index:
+  num_replica: 1
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.num_replica
+# => 1
+```
+
+---
+
+## Defaults bucket to connection bucket
+
+Given:
+
+```yaml
+bucket: fleet-dev
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-dev"
+```
+
+---
+
+## Allows explicit index bucket override
+
+Given:
+
+```yaml
+bucket: fleet-dev
+
+index:
+  bucket: fleet-indexes
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-indexes"
+```
+
+---
+
+## Preserves defaults
+
+Given:
+
+```yaml
+bucket: fleet-dev
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.migrations_path
+# => "db/indexes"
+
+CouchbaseOrm.config.index.num_replica
+# => 0
+```
+
+---
+
+## Ignores unknown keys
+
+Given:
+
+```yaml
+index:
+  foo: bar
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.respond_to?(:foo)
+# => false
+```
+
+and no exception is raised.
+
+---
+
+## Supports runtime override
+
+After Rails initialization:
+
+```ruby
+CouchbaseOrm.configure do |config|
+  config.index.num_replica = 2
+end
+```
+
+Expect:
+
+```ruby
+CouchbaseOrm.config.index.num_replica
+# => 2
+```
+
+---
+
+# V1 Complete
+
+Supported:
+
+* `migrations_path`
+* `bucket`
+* `num_replica`
+* bucket inheritance from connection configuration
+* explicit bucket override
+* runtime override via `CouchbaseOrm.configure`
+
+Not supported:
+
+* automatic migration execution
+* additional index settings
+* non-Rails configuration changes
+* validation of unknown keys
+* environment-specific runtime reload

--- a/specs/003-add-index-config-for-rails/spec.md
+++ b/specs/003-add-index-config-for-rails/spec.md
@@ -1,0 +1,223 @@
+# Spec: Index Migration Configuration for Rails Railtie
+
+## Motivation
+
+The existing Railtie already loads connection settings from `config/couchbase.yml` using:
+
+```ruby
+CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
+```
+
+Index migration settings should follow the same approach so that Rails users can configure everything in a single file.
+
+Today, index migration settings are only configurable through Ruby:
+
+```ruby
+CouchbaseOrm.configure do |config|
+  config.index.bucket = "fleet-prod"
+  config.index.num_replica = 1
+  config.index.migrations_path = "db/indexes"
+end
+```
+
+This feature allows index settings to be configured from `config/couchbase.yml` while preserving existing behavior.
+
+---
+
+# Goals
+
+* Configure index migration settings from `config/couchbase.yml`.
+* Reuse the same configuration loading mechanism as connection settings.
+* Preserve default values when index settings are absent.
+* Reuse the connection bucket by default.
+* Preserve existing non-Rails behavior.
+* Allow runtime overrides through `CouchbaseOrm.configure`.
+
+---
+
+# Non-Goals
+
+* Introducing additional index migration settings.
+* Running index migrations automatically during Rails boot.
+* Replacing the existing `CouchbaseOrm.configure` API.
+
+---
+
+# YAML Configuration
+
+Index migration settings are nested under `index`.
+
+Example:
+
+```yaml
+common: &common
+  connection_string: couchbase://localhost
+  username: dev_user
+  password: dev_password
+
+development:
+  <<: *common
+  bucket: fleet-dev
+
+  index:
+    migrations_path: db/indexes
+    num_replica: 0
+
+production:
+  connection_string: <%= ENV['COUCHBASE_CONNECTION_STRING'] %>
+  bucket: <%= ENV['COUCHBASE_BUCKET'] %>
+  username: <%= ENV['COUCHBASE_USER'] %>
+  password: <%= ENV['COUCHBASE_PASSWORD'] %>
+
+  index:
+    bucket: <%= ENV['COUCHBASE_INDEX_BUCKET'] %>
+    num_replica: 1
+```
+
+---
+
+# Railtie Changes
+
+## Existing initializer
+
+The existing initializer remains unchanged:
+
+```ruby
+initializer 'couchbase_orm.setup_connection_config' do
+  CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
+end
+```
+
+## New initializer
+
+A new initializer is added after connection configuration:
+
+```ruby
+initializer 'couchbase_orm.setup_index_config',
+            after: 'couchbase_orm.setup_connection_config' do
+  config_hash = Rails.application.config_for(:couchbase).with_indifferent_access
+  index_hash = (config_hash[:index] || {}).with_indifferent_access
+
+  index_config = {
+    bucket: config_hash[:bucket]
+  }.merge(
+    index_hash.slice(
+      :bucket,
+      :migrations_path,
+      :num_replica
+    )
+  )
+
+  index_config.each do |key, value|
+    CouchbaseOrm.config.index.public_send("#{key}=", value)
+  end
+end
+```
+
+Only keys present in the YAML configuration are applied.
+
+Unknown keys are ignored.
+
+---
+
+# Defaults
+
+Defaults from `CouchbaseOrm::Configuration::Index` are preserved.
+
+| Setting         | Default        |
+| --------------- | -------------- |
+| migrations_path | `"db/indexes"` |
+| bucket          | `nil`          |
+| num_replica     | `0`            |
+
+---
+
+# Bucket Resolution
+
+By default, index migrations use the same bucket as the connection configuration.
+
+Example:
+
+```yaml
+development:
+  bucket: fleet-dev
+```
+
+results in:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-dev"
+```
+
+The bucket may be overridden explicitly:
+
+```yaml
+development:
+  bucket: fleet-dev
+
+  index:
+    bucket: fleet-indexes
+```
+
+resulting in:
+
+```ruby
+CouchbaseOrm.config.index.bucket
+# => "fleet-indexes"
+```
+
+---
+
+# Behavior
+
+## Configuration Source
+
+Connection settings and index migration settings are both loaded from:
+
+```ruby
+Rails.application.config_for(:couchbase)
+```
+
+using the environment-specific entry in `config/couchbase.yml`.
+
+---
+
+## Precedence
+
+Configuration values are applied in the following order:
+
+1. Defaults from `CouchbaseOrm::Configuration::Index`.
+2. Connection bucket from `config/couchbase.yml`.
+3. Values from the nested `index` section.
+4. Any later explicit `CouchbaseOrm.configure` call.
+
+This preserves the ability to override configuration at runtime.
+
+---
+
+# Acceptance Criteria
+
+1. When `index.migrations_path` is defined in `config/couchbase.yml`,
+   `CouchbaseOrm.config.index.migrations_path` matches the configured value.
+
+2. When `index.num_replica` is defined,
+   `CouchbaseOrm.config.index.num_replica` matches the configured value.
+
+3. When `index.bucket` is absent,
+   `CouchbaseOrm.config.index.bucket` equals the connection bucket.
+
+4. When `index.bucket` is present,
+   it overrides the connection bucket.
+
+5. When the `index` section is absent,
+   defaults remain unchanged except that the index bucket defaults to the connection bucket.
+
+6. The `couchbase_orm.setup_index_config` initializer runs after
+   `couchbase_orm.setup_connection_config`.
+
+7. Existing non-Rails usage through `CouchbaseOrm.configure` remains unchanged.
+
+8. Explicit calls to `CouchbaseOrm.configure` made after Rails initialization override values loaded from YAML.
+
+9. Unknown keys under `index` are ignored.


### PR DESCRIPTION
# Spec: Index Migration Configuration for Rails Railtie

## Motivation

The existing Railtie already loads connection settings from `config/couchbase.yml` using:

```ruby
CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
```

Index migration settings should follow the same approach so that Rails users can configure everything in a single file.

Today, index migration settings are only configurable through Ruby:

```ruby
CouchbaseOrm.configure do |config|
  config.index.bucket = "fleet-prod"
  config.index.num_replica = 1
  config.index.migrations_path = "db/indexes"
end
```

This feature allows index settings to be configured from `config/couchbase.yml` while preserving existing behavior.

---

# Goals

* Configure index migration settings from `config/couchbase.yml`.
* Reuse the same configuration loading mechanism as connection settings.
* Preserve default values when index settings are absent.
* Reuse the connection bucket by default.
* Preserve existing non-Rails behavior.
* Allow runtime overrides through `CouchbaseOrm.configure`.

---

# Non-Goals

* Introducing additional index migration settings.
* Running index migrations automatically during Rails boot.
* Replacing the existing `CouchbaseOrm.configure` API.

---

# YAML Configuration

Index migration settings are nested under `index`.

Example:

```yaml
common: &common
  connection_string: couchbase://localhost
  username: dev_user
  password: dev_password

development:
  <<: *common
  bucket: fleet-dev

  index:
    migrations_path: db/indexes
    num_replica: 0

production:
  connection_string: <%= ENV['COUCHBASE_CONNECTION_STRING'] %>
  bucket: <%= ENV['COUCHBASE_BUCKET'] %>
  username: <%= ENV['COUCHBASE_USER'] %>
  password: <%= ENV['COUCHBASE_PASSWORD'] %>

  index:
    bucket: <%= ENV['COUCHBASE_INDEX_BUCKET'] %>
    num_replica: 1
```

---

# Railtie Changes

## Existing initializer

The existing initializer remains unchanged:

```ruby
initializer 'couchbase_orm.setup_connection_config' do
  CouchbaseOrm::Connection.config = Rails.application.config_for(:couchbase)
end
```

## New initializer

A new initializer is added after connection configuration:

```ruby
initializer 'couchbase_orm.setup_index_config',
            after: 'couchbase_orm.setup_connection_config' do
  config_hash = Rails.application.config_for(:couchbase).with_indifferent_access
  index_hash = (config_hash[:index] || {}).with_indifferent_access

  index_config = {
    bucket: config_hash[:bucket]
  }.merge(
    index_hash.slice(
      :bucket,
      :migrations_path,
      :num_replica
    )
  )

  index_config.each do |key, value|
    CouchbaseOrm.config.index.public_send("#{key}=", value)
  end
end
```

Only keys present in the YAML configuration are applied.

Unknown keys are ignored.

---

# Defaults

Defaults from `CouchbaseOrm::Configuration::Index` are preserved.

| Setting         | Default        |
| --------------- | -------------- |
| migrations_path | `"db/indexes"` |
| bucket          | `nil`          |
| num_replica     | `0`            |

---

# Bucket Resolution

By default, index migrations use the same bucket as the connection configuration.

Example:

```yaml
development:
  bucket: fleet-dev
```

results in:

```ruby
CouchbaseOrm.config.index.bucket
# => "fleet-dev"
```

The bucket may be overridden explicitly:

```yaml
development:
  bucket: fleet-dev

  index:
    bucket: fleet-indexes
```

resulting in:

```ruby
CouchbaseOrm.config.index.bucket
# => "fleet-indexes"
```

---

# Behavior

## Configuration Source

Connection settings and index migration settings are both loaded from:

```ruby
Rails.application.config_for(:couchbase)
```

using the environment-specific entry in `config/couchbase.yml`.

---

## Precedence

Configuration values are applied in the following order:

1. Defaults from `CouchbaseOrm::Configuration::Index`.
2. Connection bucket from `config/couchbase.yml`.
3. Values from the nested `index` section.
4. Any later explicit `CouchbaseOrm.configure` call.

This preserves the ability to override configuration at runtime.

---

# Acceptance Criteria

1. When `index.migrations_path` is defined in `config/couchbase.yml`,
   `CouchbaseOrm.config.index.migrations_path` matches the configured value.

2. When `index.num_replica` is defined,
   `CouchbaseOrm.config.index.num_replica` matches the configured value.

3. When `index.bucket` is absent,
   `CouchbaseOrm.config.index.bucket` equals the connection bucket.

4. When `index.bucket` is present,
   it overrides the connection bucket.

5. When the `index` section is absent,
   defaults remain unchanged except that the index bucket defaults to the connection bucket.

6. The `couchbase_orm.setup_index_config` initializer runs after
   `couchbase_orm.setup_connection_config`.

7. Existing non-Rails usage through `CouchbaseOrm.configure` remains unchanged.

8. Explicit calls to `CouchbaseOrm.configure` made after Rails initialization override values loaded from YAML.

9. Unknown keys under `index` are ignored.
