### PR TITLE
add wait until index build

### DIFF
--- a/docs/reference/index-migrations.txt
+++ b/docs/reference/index-migrations.txt
@@ -145,6 +145,12 @@ Example generated query:
 
   build_indexes :type_company, :date_on_type
 
+To wait until all built indexes are online, pass ``wait: true``:
+
+.. code-block:: ruby
+
+  build_indexes :type_company, :date_on_type, wait: true
+
 Example generated query:
 
 .. code-block:: sql
@@ -154,6 +160,21 @@ Example generated query:
     `type_company`,
     `date_on_type`
   );
+
+When ``wait: true`` is used, CouchbaseOrm polls ``system:indexes`` after the
+``BUILD INDEX`` statement and resumes when every requested index reports
+``state = online``.
+
+Polling query shape:
+
+.. code-block:: sql
+
+  SELECT name, state
+  FROM system:indexes
+  WHERE keyspace_id = 'fleet-prod'
+    AND name IN ['type_company', 'date_on_type']
+
+Polling runs every second and does not apply a timeout.
 
 ``remove_index`` drops an index:
 
@@ -257,6 +278,22 @@ Generated operations:
     `type_company`,
     `date_on_type`
   );
+
+Safe replacement flows can wait for readiness before removing old indexes:
+
+.. code-block:: ruby
+
+  class ChangeFleetByCompanyIndex < CouchbaseOrm::IndexMigration
+    def up
+      add_index :fleet_by_company_v2,
+        keys: [:type, :company_id],
+        defer_build: true
+
+      build_indexes :fleet_by_company_v2, wait: true
+
+      remove_index :fleet_by_company
+    end
+  end
 
 No internal tracking of deferred indexes is performed; migrations must call
 ``build_indexes`` explicitly when builds are required.

--- a/lib/couchbase-orm/index_migration.rb
+++ b/lib/couchbase-orm/index_migration.rb
@@ -28,15 +28,16 @@ module CouchbaseOrm
       end
 
       class BuildIndexes
-        attr_reader :index_names
+        attr_reader :index_names, :wait
 
-        def initialize(index_names)
+        def initialize(index_names, wait: false)
           @index_names = Array(index_names).flatten
+          @wait = wait
           raise ArgumentError.new('At least one index name is required') if @index_names.empty?
         end
 
         def execute(migration)
-          migration.execute_build_indexes(index_names)
+          migration.execute_build_indexes(index_names, wait: wait)
         end
 
         def inverse
@@ -74,6 +75,43 @@ module CouchbaseOrm
         @operations.reverse_each do |operation|
           operation.inverse.execute(migration)
         end
+      end
+    end
+
+    class IndexStateFetcher
+      def initialize(execute_query:)
+        @execute_query = execute_query
+      end
+
+      def states(bucket, index_names)
+        result = @execute_query.call(build_states_query(bucket, index_names))
+
+        result.rows.to_a.each_with_object({}) do |row, states|
+          name = row['name'] || row[:name]
+          state = row['state'] || row[:state]
+          states[name.to_s] = state.to_s.downcase
+        end
+      end
+
+      def online?(bucket, index_names)
+        states_by_name = states(bucket, index_names)
+        Array(index_names).map(&:to_s).all? { |name| states_by_name[name] == 'online' }
+      end
+
+      private
+
+      def build_states_query(bucket, index_names)
+        names = Array(index_names).map { |name| quote(name.to_s) }.join(', ')
+        <<~SQL.strip
+          SELECT name, state
+          FROM system:indexes
+          WHERE keyspace_id = #{quote(bucket.to_s)}
+            AND name IN [#{names}]
+        SQL
+      end
+
+      def quote(value)
+        "'#{value.gsub("'", "''")}'"
       end
     end
 
@@ -143,7 +181,11 @@ module CouchbaseOrm
     end
 
     def build_indexes(*index_names)
-      execute_operation(Operations::BuildIndexes.new(index_names))
+      options = index_names.last.is_a?(Hash) ? index_names.pop : {}
+      unknown_keys = options.keys - [:wait]
+      raise ArgumentError.new("Unknown option(s): #{unknown_keys.join(', ')}") if unknown_keys.any?
+
+      execute_operation(Operations::BuildIndexes.new(index_names, wait: options.fetch(:wait, false)))
     end
 
     def execute_add_index(name, keys:, where: nil, defer_build: false)
@@ -154,8 +196,9 @@ module CouchbaseOrm
       execute_query(query_builder.remove_index(name))
     end
 
-    def execute_build_indexes(index_names)
+    def execute_build_indexes(index_names, wait: false)
       execute_query(query_builder.build_indexes(index_names))
+      wait_for_indexes_online(index_names) if wait
     end
 
     private
@@ -197,8 +240,33 @@ module CouchbaseOrm
       CouchbaseOrm::Connection.cluster.query(query, Couchbase::Options::Query.new)
     end
 
+    def wait_for_indexes_online(index_names)
+      names = Array(index_names).map(&:to_s)
+
+      loop do
+        return if index_state_fetcher.online?(index_bucket, names)
+
+        sleep(index_build_wait_interval_seconds)
+      end
+    end
+
     def query_builder
       @query_builder ||= QueryBuilder.new
+    end
+
+    def index_state_fetcher
+      @index_state_fetcher ||= IndexStateFetcher.new(execute_query: method(:execute_query))
+    end
+
+    def index_bucket
+      bucket = CouchbaseOrm.config.index.effective_bucket
+      raise ArgumentError.new('Missing index bucket configuration') if bucket.to_s.strip.empty?
+
+      bucket
+    end
+
+    def index_build_wait_interval_seconds
+      1
     end
 
     def method_overridden?(method_name)

--- a/spec/index_migration_spec.rb
+++ b/spec/index_migration_spec.rb
@@ -131,7 +131,7 @@ describe CouchbaseOrm::IndexMigration do
 
     expect(migration).to receive(:execute_operation) do |operation|
       expect(operation.index_names).to eq([:type_company])
-      expect(operation.wait).to eq(false)
+      expect(operation.wait).to be(false)
     end
 
     migration.build_indexes(:type_company)
@@ -142,7 +142,7 @@ describe CouchbaseOrm::IndexMigration do
 
     expect(migration).to receive(:execute_operation) do |operation|
       expect(operation.index_names).to eq([:type_company])
-      expect(operation.wait).to eq(true)
+      expect(operation.wait).to be(true)
     end
 
     migration.build_indexes(:type_company, wait: true)
@@ -182,7 +182,7 @@ describe CouchbaseOrm::IndexMigration do
     poll_count = 0
     allow(cluster).to receive(:query) do |query, _options|
       if query.start_with?('BUILD INDEX ON')
-        instance_double('QueryResult', rows: [])
+        instance_double(Couchbase::Cluster::QueryResult, rows: [])
       elsif query.include?('FROM system:indexes')
         poll_count += 1
         rows = if poll_count == 1
@@ -196,16 +196,15 @@ describe CouchbaseOrm::IndexMigration do
                    { 'name' => 'date_on_type', 'state' => 'online' }
                  ]
                end
-        instance_double('QueryResult', rows: rows)
+        instance_double(Couchbase::Cluster::QueryResult, rows: rows)
       end
     end
 
     migration = migration_class.new
-    allow(migration).to receive(:sleep)
+    expect(migration).to receive(:sleep).once
     migration.migrate(:up)
 
     expect(poll_count).to eq(2)
-    expect(migration).to have_received(:sleep).once
   end
 
   it 'raises irreversible migration when build_indexes is used in change' do

--- a/spec/index_migration_spec.rb
+++ b/spec/index_migration_spec.rb
@@ -126,6 +126,88 @@ describe CouchbaseOrm::IndexMigration do
       .to raise_error(ArgumentError, /At least one index name is required/)
   end
 
+  it 'build_indexes sets wait to false by default' do
+    migration = described_class.new
+
+    expect(migration).to receive(:execute_operation) do |operation|
+      expect(operation.index_names).to eq([:type_company])
+      expect(operation.wait).to eq(false)
+    end
+
+    migration.build_indexes(:type_company)
+  end
+
+  it 'build_indexes sets wait to true when provided' do
+    migration = described_class.new
+
+    expect(migration).to receive(:execute_operation) do |operation|
+      expect(operation.index_names).to eq([:type_company])
+      expect(operation.wait).to eq(true)
+    end
+
+    migration.build_indexes(:type_company, wait: true)
+  end
+
+  it 'does not poll index states when build_indexes wait is false' do
+    migration_class = Class.new(CouchbaseOrm::IndexMigration) do
+      def up
+        build_indexes :type_company
+      end
+    end
+
+    cluster = instance_double(Couchbase::Cluster)
+    allow(CouchbaseOrm::Connection).to receive(:cluster).and_return(cluster)
+
+    expect(cluster).to receive(:query).with(<<~SQL.strip, instance_of(Couchbase::Options::Query))
+      BUILD INDEX ON `fleet-prod`
+      (
+        `type_company`
+      );
+    SQL
+    expect(cluster).not_to receive(:query).with(/FROM system:indexes/, instance_of(Couchbase::Options::Query))
+
+    migration_class.new.migrate(:up)
+  end
+
+  it 'polls until all indexes are online when build_indexes wait is true' do
+    migration_class = Class.new(CouchbaseOrm::IndexMigration) do
+      def up
+        build_indexes :type_company, :date_on_type, wait: true
+      end
+    end
+
+    cluster = instance_double(Couchbase::Cluster)
+    allow(CouchbaseOrm::Connection).to receive(:cluster).and_return(cluster)
+
+    poll_count = 0
+    allow(cluster).to receive(:query) do |query, _options|
+      if query.start_with?('BUILD INDEX ON')
+        instance_double('QueryResult', rows: [])
+      elsif query.include?('FROM system:indexes')
+        poll_count += 1
+        rows = if poll_count == 1
+                 [
+                   { 'name' => 'type_company', 'state' => 'online' },
+                   { 'name' => 'date_on_type', 'state' => 'building' }
+                 ]
+               else
+                 [
+                   { 'name' => 'type_company', 'state' => 'online' },
+                   { 'name' => 'date_on_type', 'state' => 'online' }
+                 ]
+               end
+        instance_double('QueryResult', rows: rows)
+      end
+    end
+
+    migration = migration_class.new
+    allow(migration).to receive(:sleep)
+    migration.migrate(:up)
+
+    expect(poll_count).to eq(2)
+    expect(migration).to have_received(:sleep).once
+  end
+
   it 'raises irreversible migration when build_indexes is used in change' do
     migration_class = Class.new(CouchbaseOrm::IndexMigration) do
       def change

--- a/specs/003-add-wait_for_indexes_build/plan.md
+++ b/specs/003-add-wait_for_indexes_build/plan.md
@@ -1,0 +1,261 @@
+# Implementation Plan: Wait Support for `build_indexes`
+
+## Phase 1 — Extend BuildIndexes Operation
+
+Add:
+
+```ruby
+wait
+```
+
+to:
+
+```ruby
+CouchbaseOrm::IndexMigration::Operations::BuildIndexes
+```
+
+Default:
+
+```ruby
+wait = false
+```
+
+---
+
+## Phase 2 — Extend Migration DSL
+
+Support:
+
+```ruby
+build_indexes(
+  :type_company,
+  :date_on_type,
+  wait: true
+)
+```
+
+Examples:
+
+```ruby
+build_indexes :type_company
+```
+
+↓
+
+```ruby
+BuildIndexes.new(
+  [:type_company],
+  wait: false
+)
+```
+
+```ruby
+build_indexes :type_company,
+              wait: true
+```
+
+↓
+
+```ruby
+BuildIndexes.new(
+  [:type_company],
+  wait: true
+)
+```
+
+---
+
+## Phase 3 — Preserve Existing BUILD INDEX Behavior
+
+Continue generating:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`,
+  `date_on_type`
+);
+```
+
+When:
+
+```ruby
+wait == false
+```
+
+execution finishes immediately.
+
+---
+
+## Phase 4 — Add Wait Logic
+
+When:
+
+```ruby
+wait == true
+```
+
+after executing:
+
+```sql
+BUILD INDEX ...
+```
+
+poll:
+
+```sql
+SELECT name, state
+FROM system:indexes
+WHERE keyspace_id = $bucket
+AND name IN $index_names
+```
+
+until every index satisfies:
+
+```ruby
+state == "online"
+```
+
+---
+
+## Phase 5 — Introduce IndexStateFetcher
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexMigration::IndexStateFetcher
+```
+
+Responsibilities:
+
+```ruby
+states(bucket, index_names)
+online?(bucket, index_names)
+```
+
+Encapsulate the query:
+
+```sql
+SELECT name, state
+FROM system:indexes
+WHERE keyspace_id = $bucket
+AND name IN $index_names
+```
+
+---
+
+## Phase 6 — Polling Strategy
+
+Use:
+
+```ruby
+sleep(1)
+```
+
+Pseudo-code:
+
+```ruby
+loop do
+  states = fetch_index_states
+
+  break if states.all? { |state| state == "online" }
+
+  sleep(1)
+end
+```
+
+No timeout is introduced.
+
+---
+
+## Phase 7 — Preserve Rollback Semantics
+
+Rollback of:
+
+```ruby
+def change
+  build_indexes :type_company,
+                wait: true
+end
+```
+
+continues to raise:
+
+```ruby
+CouchbaseOrm::IrreversibleMigration
+```
+
+---
+
+## Phase 8 — Tests
+
+### Default
+
+Given:
+
+```ruby
+build_indexes :type_company
+```
+
+Expect:
+
+```ruby
+operation.wait
+# => false
+```
+
+and no polling.
+
+### Explicit wait
+
+Given:
+
+```ruby
+build_indexes :type_company,
+              wait: true
+```
+
+Expect:
+
+```ruby
+operation.wait
+# => true
+```
+
+and polling until:
+
+```ruby
+state == "online"
+```
+
+### Multiple indexes
+
+Given:
+
+```ruby
+build_indexes :type_company,
+              :date_on_type,
+              wait: true
+```
+
+Expect execution to resume only when both indexes are online.
+
+---
+
+# V1 Complete
+
+Supported:
+
+* `build_indexes(*names)`
+* `build_indexes(*names, wait: true)`
+* polling `system:indexes`
+* multiple indexes
+
+Not supported:
+
+* configurable timeout
+* configurable polling interval
+* progress reporting
+* scope/collection support
+* standalone `wait_for_indexes`
+* retry mechanisms

--- a/specs/003-add-wait_for_indexes_build/spec.md
+++ b/specs/003-add-wait_for_indexes_build/spec.md
@@ -1,0 +1,275 @@
+# Spec: Wait Support for `build_indexes`
+
+## Motivation
+
+`BUILD INDEX` in Couchbase is asynchronous.
+
+Executing:
+
+```sql
+BUILD INDEX ON `bucket`(`type_company`);
+```
+
+returns immediately while the index may still be in the `building` state.
+
+This is usually acceptable when creating new indexes, but can be dangerous when replacing an existing index:
+
+```ruby
+add_index :type_company_v2,
+  keys: [:type, :company_id],
+  defer_build: true
+
+build_indexes :type_company_v2
+
+remove_index :type_company
+```
+
+If the old index is removed before the new index becomes `online`, queries may fail or experience degraded performance.
+
+CouchbaseORM should provide an explicit way to wait for indexes to become online.
+
+---
+
+# Goals
+
+* Provide explicit waiting semantics.
+* Keep waiting opt-in.
+* Avoid introducing additional DSL methods.
+* Keep the API simple and close to ActiveRecord.
+* Prevent accidental production outages during index replacement.
+
+---
+
+# Non-Goals
+
+* Automatically waiting after every build.
+* Monitoring index progress.
+* Configurable timeout.
+* Rebuilding indexes automatically.
+* Polling indexes outside explicit user requests.
+
+---
+
+# DSL
+
+Current:
+
+```ruby
+build_indexes :type_company
+```
+
+New:
+
+```ruby
+build_indexes :type_company, wait: true
+```
+
+Multiple indexes:
+
+```ruby
+build_indexes :type_company,
+              :date_on_type,
+              wait: true
+```
+
+---
+
+# Behavior
+
+## wait: false (default)
+
+```ruby
+build_indexes :type_company
+```
+
+Generates:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`
+);
+```
+
+No additional polling is performed.
+
+---
+
+## wait: true
+
+```ruby
+build_indexes :type_company,
+              wait: true
+```
+
+Execution flow:
+
+1. Execute:
+
+```sql
+BUILD INDEX ON `bucket`
+(
+  `type_company`
+);
+```
+
+2. Poll:
+
+```sql
+SELECT name, state
+FROM system:indexes
+WHERE keyspace_id = $bucket
+AND name IN $index_names
+```
+
+3. Continue when every index reaches:
+
+```text
+online
+```
+
+---
+
+# Polling Strategy
+
+Polling interval:
+
+```ruby
+1.second
+```
+
+No timeout is applied.
+
+The operation waits indefinitely until all indexes become online.
+
+---
+
+# Operation
+
+Extend:
+
+```ruby
+CouchbaseOrm::IndexMigration::Operations::BuildIndexes
+```
+
+with:
+
+```ruby
+index_names
+wait
+```
+
+Default:
+
+```ruby
+wait: false
+```
+
+---
+
+# Reversibility
+
+`build_indexes` remains irreversible.
+
+Therefore:
+
+```ruby
+def change
+  build_indexes :type_company,
+                wait: true
+end
+```
+
+raises:
+
+```ruby
+CouchbaseOrm::IrreversibleMigration
+```
+
+during rollback.
+
+Complex migrations should use:
+
+```ruby
+def up
+end
+
+def down
+end
+```
+
+---
+
+# Example
+
+Safe index replacement:
+
+```ruby
+class ChangeFleetByCompanyIndex < CouchbaseOrm::IndexMigration
+  def up
+    add_index :fleet_by_company_v2,
+      keys: [:type, :company_id],
+      defer_build: true
+
+    build_indexes :fleet_by_company_v2,
+                  wait: true
+
+    remove_index :fleet_by_company
+  end
+
+  def down
+    add_index :fleet_by_company,
+      keys: [:company_id, :type],
+      defer_build: true
+
+    build_indexes :fleet_by_company,
+                  wait: true
+
+    remove_index :fleet_by_company_v2
+  end
+end
+```
+
+---
+
+# Acceptance Criteria
+
+### Default behavior
+
+Given:
+
+```ruby
+build_indexes :type_company
+```
+
+Then:
+
+* `BUILD INDEX` is executed;
+* no polling is performed.
+
+### Wait behavior
+
+Given:
+
+```ruby
+build_indexes :type_company,
+              wait: true
+```
+
+Then:
+
+* `BUILD INDEX` is executed;
+* `system:indexes` is polled;
+* execution resumes only when the index becomes `online`.
+
+### Multiple indexes
+
+Given:
+
+```ruby
+build_indexes :type_company,
+              :date_on_type,
+              wait: true
+```
+
+Then execution resumes only when both indexes are online.


### PR DESCRIPTION
# Spec: Wait Support for `build_indexes`

## Motivation

`BUILD INDEX` in Couchbase is asynchronous.

Executing:

```sql
BUILD INDEX ON `bucket`(`type_company`);
```

returns immediately while the index may still be in the `building` state.

This is usually acceptable when creating new indexes, but can be dangerous when replacing an existing index:

```ruby
add_index :type_company_v2,
  keys: [:type, :company_id],
  defer_build: true

build_indexes :type_company_v2

remove_index :type_company
```

If the old index is removed before the new index becomes `online`, queries may fail or experience degraded performance.

CouchbaseORM should provide an explicit way to wait for indexes to become online.

---

# Goals

* Provide explicit waiting semantics.
* Keep waiting opt-in.
* Avoid introducing additional DSL methods.
* Keep the API simple and close to ActiveRecord.
* Prevent accidental production outages during index replacement.

---

# Non-Goals

* Automatically waiting after every build.
* Monitoring index progress.
* Configurable timeout.
* Rebuilding indexes automatically.
* Polling indexes outside explicit user requests.

---

# DSL

Current:

```ruby
build_indexes :type_company
```

New:

```ruby
build_indexes :type_company, wait: true
```

Multiple indexes:

```ruby
build_indexes :type_company,
              :date_on_type,
              wait: true
```

---

# Behavior

## wait: false (default)

```ruby
build_indexes :type_company
```

Generates:

```sql
BUILD INDEX ON `bucket`
(
  `type_company`
);
```

No additional polling is performed.

---

## wait: true

```ruby
build_indexes :type_company,
              wait: true
```

Execution flow:

1. Execute:

```sql
BUILD INDEX ON `bucket`
(
  `type_company`
);
```

2. Poll:

```sql
SELECT name, state
FROM system:indexes
WHERE keyspace_id = $bucket
AND name IN $index_names
```

3. Continue when every index reaches:

```text
online
```

---

# Polling Strategy

Polling interval:

```ruby
1.second
```

No timeout is applied.

The operation waits indefinitely until all indexes become online.

---

# Operation

Extend:

```ruby
CouchbaseOrm::IndexMigration::Operations::BuildIndexes
```

with:

```ruby
index_names
wait
```

Default:

```ruby
wait: false
```

---

# Reversibility

`build_indexes` remains irreversible.

Therefore:

```ruby
def change
  build_indexes :type_company,
                wait: true
end
```

raises:

```ruby
CouchbaseOrm::IrreversibleMigration
```

during rollback.

Complex migrations should use:

```ruby
def up
end

def down
end
```

---

# Example

Safe index replacement:

```ruby
class ChangeFleetByCompanyIndex < CouchbaseOrm::IndexMigration
  def up
    add_index :fleet_by_company_v2,
      keys: [:type, :company_id],
      defer_build: true

    build_indexes :fleet_by_company_v2,
                  wait: true

    remove_index :fleet_by_company
  end

  def down
    add_index :fleet_by_company,
      keys: [:company_id, :type],
      defer_build: true

    build_indexes :fleet_by_company,
                  wait: true

    remove_index :fleet_by_company_v2
  end
end
```

---

# Acceptance Criteria

### Default behavior

Given:

```ruby
build_indexes :type_company
```

Then:

* `BUILD INDEX` is executed;
* no polling is performed.

### Wait behavior

Given:

```ruby
build_indexes :type_company,
              wait: true
```

Then:

* `BUILD INDEX` is executed;
* `system:indexes` is polled;
* execution resumes only when the index becomes `online`.

### Multiple indexes

Given:

```ruby
build_indexes :type_company,
              :date_on_type,
              wait: true
```

Then execution resumes only when both indexes are online.
