### PR TITLE
add in initial index migration generator

### DIFF
--- a/lib/couchbase-orm/index_migration.rb
+++ b/lib/couchbase-orm/index_migration.rb
@@ -5,6 +5,10 @@ require 'couchbase'
 
 module CouchbaseOrm
   class IndexMigration
+    autoload :IndexDefinition, 'couchbase-orm/index_migration/index_definition'
+    autoload :IndexIntrospector, 'couchbase-orm/index_migration/index_introspector'
+    autoload :MigrationGenerator, 'couchbase-orm/index_migration/migration_generator'
+
     class IrreversibleMigration < StandardError; end
 
     module Operations

--- a/lib/couchbase-orm/index_migration/index_definition.rb
+++ b/lib/couchbase-orm/index_migration/index_definition.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CouchbaseOrm
+  class IndexMigration
+    class IndexDefinition
+      attr_reader :name, :keys, :where
+
+      def initialize(name:, keys:, where: nil)
+        @name = name.to_s
+        @keys = normalize_keys(keys)
+        @where = normalize_where(where)
+      end
+
+      def self.from_introspected(index_data)
+        new(
+          name: index_data.fetch(:name),
+          keys: index_data.fetch(:index_key, []),
+          where: index_data[:condition]
+        )
+      end
+
+      def <=>(other)
+        name <=> other.name
+      end
+
+      private
+
+      def normalize_keys(raw_keys)
+        Array(raw_keys).map { |key| normalize_key(key) }
+      end
+
+      def normalize_key(key)
+        value = key.to_s.strip
+        match = value.match(/\A`?([a-zA-Z_][a-zA-Z0-9_]*)`?\z/)
+        return match[1].to_sym if match
+
+        value
+      end
+
+      def normalize_where(where)
+        stripped = where.to_s.strip
+        stripped.empty? ? nil : stripped
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_migration/index_introspector.rb
+++ b/lib/couchbase-orm/index_migration/index_introspector.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module CouchbaseOrm
+  class IndexMigration
+    class IndexIntrospector
+      def initialize(execute_query: nil)
+        @execute_query = execute_query || method(:default_execute_query)
+      end
+
+      def indexes(bucket: configured_bucket)
+        bucket_name = bucket.to_s
+        raise ArgumentError.new('Missing index bucket configuration') if bucket_name.strip.empty?
+
+        result = @execute_query.call(query_for(bucket_name))
+        rows = result.respond_to?(:rows) ? result.rows : []
+
+        Array(rows).map { |row| normalize_row(row) }
+                   .select { |row| row[:keyspace_id] == bucket_name }
+                   .reject { |row| row[:is_primary] }
+                   .sort_by { |row| row[:name] }
+                   .map { |row| row.slice(:name, :index_key, :condition, :state) }
+      end
+
+      private
+
+      def configured_bucket
+        CouchbaseOrm.config.index.effective_bucket
+      end
+
+      def query_for(bucket_name)
+        <<~SQL.strip
+          SELECT *
+          FROM system:indexes
+          WHERE keyspace_id = #{quote(bucket_name)}
+        SQL
+      end
+
+      def quote(value)
+        "'#{value.gsub("'", "''")}'"
+      end
+
+      def normalize_row(row)
+        data = row.respond_to?(:transform_keys) ? row : row.to_h
+        index_data = data['indexes'] || data[:indexes] || data
+
+        {
+          name: fetch(index_data, :name).to_s,
+          index_key: Array(fetch(index_data, :index_key)),
+          condition: normalize_condition(fetch(index_data, :condition)),
+          state: fetch(index_data, :state).to_s,
+          is_primary: fetch(index_data, :is_primary),
+          keyspace_id: fetch(index_data, :keyspace_id).to_s
+        }
+      end
+
+      def fetch(hash, key)
+        hash[key] || hash[key.to_s]
+      end
+
+      def normalize_condition(value)
+        stripped = value.to_s.strip
+        stripped.empty? ? nil : stripped
+      end
+
+      def default_execute_query(query)
+        CouchbaseOrm::Connection.cluster.query(query, Couchbase::Options::Query.new)
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_migration/migration_generator.rb
+++ b/lib/couchbase-orm/index_migration/migration_generator.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'active_support/core_ext/string/inflections'
+
+module CouchbaseOrm
+  class IndexMigration
+    class MigrationGenerator
+      DEFAULT_NAME = 'InitialIndexes'
+
+      def initialize(path: CouchbaseOrm.config.index.migrations_path, now: Time.now)
+        @path = path
+        @now = now
+      end
+
+      def generate(index_definitions, name: DEFAULT_NAME)
+        class_name = migration_class_name(name)
+        timestamp = @now.utc.strftime('%Y%m%d%H%M%S')
+        file_name = "#{timestamp}_#{class_name.underscore}.rb"
+        file_path = File.join(@path, file_name)
+
+        FileUtils.mkdir_p(@path)
+        File.write(file_path, source_for(index_definitions, class_name: class_name))
+        file_path
+      end
+
+      def source_for(index_definitions, class_name: DEFAULT_NAME)
+        definitions = Array(index_definitions).sort_by(&:name)
+
+        <<~RUBY
+          class #{migration_class_name(class_name)} < CouchbaseOrm::IndexMigration
+            def up
+          #{up_body(definitions)}
+            end
+
+            def down
+          #{down_body(definitions)}
+            end
+          end
+        RUBY
+      end
+
+      private
+
+      def migration_class_name(name)
+        value = name.to_s.strip
+        raise ArgumentError.new('Migration name is required') if value.empty?
+
+        value.camelize
+      end
+
+      def up_body(definitions)
+        lines = []
+
+        definitions.each_with_index do |definition, index|
+          lines.concat(add_index_lines(definition))
+          lines << '' unless index == definitions.length - 1
+        end
+
+        if definitions.any?
+          lines << ''
+          lines.concat(build_indexes_lines(definitions))
+        end
+
+        indent(lines)
+      end
+
+      def down_body(definitions)
+        lines = definitions.reverse.map { |definition| "remove_index :#{definition.name}" }
+        indent(lines)
+      end
+
+      def add_index_lines(definition)
+        lines = [
+          'add_index(',
+          "  :#{definition.name},",
+          "  keys: #{ruby_array(definition.keys)},"
+        ]
+        lines << "  where: #{definition.where.inspect}," if definition.where
+        lines << '  defer_build: true'
+        lines << ')'
+        lines
+      end
+
+      def build_indexes_lines(definitions)
+        lines = ['build_indexes(']
+        definitions.each_with_index do |definition, index|
+          suffix = index == definitions.length - 1 ? '' : ','
+          lines << "  :#{definition.name}#{suffix}"
+        end
+        lines << ')'
+        lines
+      end
+
+      def ruby_array(values)
+        "[#{Array(values).map { |value| ruby_value(value) }.join(', ')}]"
+      end
+
+      def ruby_value(value)
+        value.is_a?(Symbol) ? ":#{value}" : value.inspect
+      end
+
+      def indent(lines)
+        Array(lines).map { |line| "    #{line}" }.join("\n")
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_migrator.rb
+++ b/lib/couchbase-orm/index_migrator.rb
@@ -14,6 +14,10 @@ module CouchbaseOrm
       def status(**options)
         new(**options).status
       end
+
+      def adopt(**options)
+        new(**options).adopt
+      end
     end
 
     def initialize(context: IndexMigrationContext.new, schema_migration: IndexSchemaMigration.new, out: nil)
@@ -52,6 +56,14 @@ module CouchbaseOrm
 
       @out.puts(lines.join("\n")) unless lines.empty?
       lines
+    end
+
+    def adopt
+      migration_def = @context.migrations.max_by(&:version)
+      return nil unless migration_def
+
+      @schema_migration.add_version(migration_def.version)
+      migration_def.version
     end
   end
 end

--- a/spec/index_definition_spec.rb
+++ b/spec/index_definition_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+
+describe CouchbaseOrm::IndexMigration::IndexDefinition do
+  it 'normalizes simple keys to symbols and strips where clause' do
+    definition = described_class.from_introspected(
+      name: 'type_company',
+      index_key: ['`type`', 'company_id'],
+      condition: '  type is valued  '
+    )
+
+    expect(definition.name).to eq('type_company')
+    expect(definition.keys).to eq(%i[type company_id])
+    expect(definition.where).to eq('type is valued')
+  end
+
+  it 'keeps expression keys as strings' do
+    definition = described_class.new(name: 'by_lower_name', keys: ['LOWER(`name`)'])
+
+    expect(definition.keys).to eq(['LOWER(`name`)'])
+  end
+end

--- a/spec/index_introspector_spec.rb
+++ b/spec/index_introspector_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+
+describe CouchbaseOrm::IndexMigration::IndexIntrospector do
+  it 'filters by bucket, ignores primary indexes and sorts by name' do
+    query_result = instance_double(Couchbase::Cluster::QueryResult, rows: introspected_rows)
+    execute_query = build_execute_query(query_result)
+
+    indexes = described_class.new(execute_query: execute_query).indexes(bucket: 'fleet')
+
+    expect(indexes).to eq(expected_indexes)
+  end
+
+  it 'raises when bucket is missing' do
+    expect do
+      described_class.new(execute_query: ->(_query) { raise 'not called' }).indexes(bucket: nil)
+    end.to raise_error(ArgumentError, /Missing index bucket configuration/)
+  end
+
+  def build_execute_query(query_result)
+    lambda do |query|
+      expect(query).to include('FROM system:indexes')
+      expect(query).to include("WHERE keyspace_id = 'fleet'")
+      query_result
+    end
+  end
+
+  def introspected_rows
+    [
+      {
+        'indexes' => {
+          'name' => 'type_company',
+          'index_key' => ['`type`', '`company_id`'],
+          'condition' => 'type is valued',
+          'state' => 'online',
+          'is_primary' => false,
+          'keyspace_id' => 'fleet'
+        }
+      },
+      {
+        'indexes' => {
+          'name' => 'date_on_type',
+          'index_key' => ['`date`'],
+          'condition' => 'type is valued and date is valued',
+          'state' => 'online',
+          'is_primary' => false,
+          'keyspace_id' => 'fleet'
+        }
+      },
+      {
+        'indexes' => {
+          'name' => '#primary',
+          'index_key' => [],
+          'state' => 'online',
+          'is_primary' => true,
+          'keyspace_id' => 'fleet'
+        }
+      },
+      {
+        'indexes' => {
+          'name' => 'other_bucket_index',
+          'index_key' => ['`type`'],
+          'state' => 'online',
+          'is_primary' => false,
+          'keyspace_id' => 'other'
+        }
+      }
+    ]
+  end
+
+  def expected_indexes
+    [
+      {
+        name: 'date_on_type',
+        index_key: ['`date`'],
+        condition: 'type is valued and date is valued',
+        state: 'online'
+      },
+      {
+        name: 'type_company',
+        index_key: ['`type`', '`company_id`'],
+        condition: 'type is valued',
+        state: 'online'
+      }
+    ]
+  end
+end

--- a/spec/index_migration_migration_generator_spec.rb
+++ b/spec/index_migration_migration_generator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+require 'tmpdir'
+
+describe CouchbaseOrm::IndexMigration::MigrationGenerator do
+  let(:date_on_type) do
+    CouchbaseOrm::IndexMigration::IndexDefinition.new(
+      name: 'date_on_type',
+      keys: [:date],
+      where: 'type is valued and date is valued'
+    )
+  end
+
+  let(:type_company) do
+    CouchbaseOrm::IndexMigration::IndexDefinition.new(
+      name: 'type_company',
+      keys: %i[type company_id],
+      where: 'type is valued and company_id is valued'
+    )
+  end
+
+  it 'renders deterministic source with deferred add_index, single build_indexes and reverse down' do
+    generator = described_class.new
+
+    source = generator.source_for([type_company, date_on_type])
+
+    expect(source).to include('class InitialIndexes < CouchbaseOrm::IndexMigration')
+    expect(source).to include("add_index(\n      :date_on_type,")
+    expect(source).to include('keys: [:date],')
+    expect(source).to include('defer_build: true')
+    expect(source).to include("build_indexes(\n      :date_on_type,\n      :type_company\n    )")
+    expect(source).to include("def down\n    remove_index :type_company\n    remove_index :date_on_type\n  end")
+  end
+
+  it 'creates timestamped file with custom migration class name' do
+    Dir.mktmpdir do |dir|
+      now = Time.utc(2026, 8, 10, 12, 0, 0)
+      generator = described_class.new(path: dir, now: now)
+
+      file_path = generator.generate([type_company], name: 'FleetIndexes')
+
+      expect(File.basename(file_path)).to eq('20260810120000_fleet_indexes.rb')
+      expect(File.read(file_path)).to include('class FleetIndexes < CouchbaseOrm::IndexMigration')
+    end
+  end
+
+  it 'produces the same source content for the same index set regardless of input order' do
+    generator = described_class.new
+
+    first_source = generator.source_for([date_on_type, type_company])
+    second_source = generator.source_for([type_company, date_on_type])
+
+    expect(first_source).to eq(second_source)
+  end
+end

--- a/spec/index_migrator_spec.rb
+++ b/spec/index_migrator_spec.rb
@@ -63,4 +63,30 @@ describe CouchbaseOrm::IndexMigrator do
     expect(out.string).to include('up     20250808110000 InitialIndexes')
     expect(out.string).to include('down   20250808120000 AddWorkflowIndex')
   end
+
+  it 'adopts latest migration version without executing migration code' do
+    migration_one = CouchbaseOrm::IndexMigrationContext::Migration.new(
+      version: '20250808110000', name: 'InitialIndexes',
+      klass: Class.new, path: 'db/indexes/20250808110000_initial_indexes.rb'
+    )
+    migration_two = CouchbaseOrm::IndexMigrationContext::Migration.new(
+      version: '20250808120000', name: 'AddWorkflowIndex',
+      klass: Class.new, path: 'db/indexes/20250808120000_add_workflow_index.rb'
+    )
+    allow(context).to receive(:migrations).and_return([migration_one, migration_two])
+    expect(schema_migration).to receive(:add_version).with('20250808120000')
+
+    adopted_version = described_class.new(context: context, schema_migration: schema_migration, out: out).adopt
+
+    expect(adopted_version).to eq('20250808120000')
+  end
+
+  it 'returns nil when there are no migrations to adopt' do
+    allow(context).to receive(:migrations).and_return([])
+    expect(schema_migration).not_to receive(:add_version)
+
+    adopted_version = described_class.new(context: context, schema_migration: schema_migration, out: out).adopt
+
+    expect(adopted_version).to be_nil
+  end
 end

--- a/specs/004-add-initial-index-migration-generation/plan.md
+++ b/specs/004-add-initial-index-migration-generation/plan.md
@@ -1,0 +1,405 @@
+# Implementation Plan: Initial Index Migration Generation
+
+## Goal
+
+Allow existing Couchbase clusters to bootstrap CouchbaseORM index migrations from the indexes already present in production.
+
+This enables:
+
+* adoption of index migrations on existing projects;
+* recreation of indexes in development and staging environments;
+* future index evolution through regular migrations.
+
+---
+
+# Phase 1 — Index Introspection
+
+## Goal
+
+Read index definitions from the cluster.
+
+## Tasks
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexMigration::IndexIntrospector
+```
+
+Responsibilities:
+
+* query `system:indexes`;
+* filter indexes belonging to the configured bucket;
+* ignore primary indexes;
+* normalize metadata;
+* sort indexes alphabetically.
+
+Query:
+
+```sql
+SELECT *
+FROM system:indexes
+WHERE keyspace_id = $bucket
+```
+
+Returns:
+
+```ruby
+[
+  {
+    name: "date_on_type",
+    index_key: [...],
+    condition: "...",
+    state: "online"
+  },
+  ...
+]
+```
+
+---
+
+# Phase 2 — Index Definition Model
+
+## Goal
+
+Represent indexes independently from Couchbase metadata.
+
+## Tasks
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexMigration::IndexDefinition
+```
+
+Attributes:
+
+```ruby
+name
+keys
+where
+```
+
+Responsibilities:
+
+* parse `index_key`;
+* extract WHERE clause;
+* ignore runtime properties;
+* provide deterministic ordering.
+
+---
+
+# Phase 3 — Migration Generator
+
+## Goal
+
+Generate an InitialIndexes migration.
+
+## Tasks
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexMigration::MigrationGenerator
+```
+
+Input:
+
+```ruby
+Array<IndexDefinition>
+```
+
+Output:
+
+```ruby
+class InitialIndexes < CouchbaseOrm::IndexMigration
+  def up
+    ...
+  end
+
+  def down
+    ...
+  end
+end
+```
+
+---
+
+# Phase 4 — Generate add_index Statements
+
+## Goal
+
+Convert index definitions into DSL.
+
+Example:
+
+Cluster:
+
+```sql
+CREATE INDEX type_company
+ON bucket(type, company_id)
+WHERE type IS VALUED;
+```
+
+Produces:
+
+```ruby
+add_index(
+  :type_company,
+  keys: [:type, :company_id],
+  where: "type IS VALUED",
+  defer_build: true
+)
+```
+
+Rules:
+
+* generate indexes alphabetically;
+* always use:
+
+```ruby
+defer_build: true
+```
+
+to minimize build time.
+
+---
+
+# Phase 5 — Generate build_indexes Statement
+
+## Goal
+
+Build indexes in a single operation.
+
+Example:
+
+```ruby
+build_indexes(
+  :date_on_type,
+  :type_company,
+  :workflow_index
+)
+```
+
+Responsibilities:
+
+* use the same alphabetical ordering;
+* generate a single BUILD INDEX operation.
+
+---
+
+# Phase 6 — Generate Down Migration
+
+## Goal
+
+Support rollback.
+
+Example:
+
+```ruby
+def down
+  remove_index :workflow_index
+  remove_index :type_company
+  remove_index :date_on_type
+end
+```
+
+Rules:
+
+* reverse creation order;
+* use deterministic ordering.
+
+---
+
+# Phase 7 — Dump Task
+
+## Goal
+
+Expose generation through CLI.
+
+Command:
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+Workflow:
+
+1. load bucket configuration;
+2. introspect indexes;
+3. build index definitions;
+4. generate migration source;
+5. create:
+
+```text
+db/indexes/YYYYMMDDHHMMSS_initial_indexes.rb
+```
+
+---
+
+# Phase 8 — Custom Migration Name
+
+## Goal
+
+Support:
+
+```bash
+bundle exec couchbaseorm index:dump NAME=FleetIndexes
+```
+
+Produces:
+
+```ruby
+class FleetIndexes < CouchbaseOrm::IndexMigration
+end
+```
+
+File:
+
+```text
+db/indexes/YYYYMMDDHHMMSS_fleet_indexes.rb
+```
+
+Default:
+
+```ruby
+InitialIndexes
+```
+
+---
+
+# Phase 9 — Adopt Command
+
+## Goal
+
+Mark generated migration as already executed.
+
+Command:
+
+```bash
+bundle exec couchbaseorm index:adopt
+```
+
+Responsibilities:
+
+* locate latest index migration;
+* extract version;
+* insert version into:
+
+```ruby
+CouchbaseOrm::IndexSchemaMigration
+```
+
+without executing the migration.
+
+No indexes are modified.
+
+---
+
+# Phase 10 — Tests
+
+## IndexIntrospector
+
+* filters bucket;
+* ignores primary indexes;
+* sorts indexes by name.
+
+---
+
+## MigrationGenerator
+
+Given:
+
+```ruby
+[
+  date_on_type,
+  type_company
+]
+```
+
+Produces:
+
+```ruby
+add_index(...)
+add_index(...)
+
+build_indexes(...)
+```
+
+with:
+
+```ruby
+defer_build: true
+```
+
+---
+
+## Down Migration
+
+Produces:
+
+```ruby
+remove_index(...)
+```
+
+in reverse order.
+
+---
+
+## Deterministic Output
+
+Running:
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+twice without cluster changes generates identical migration content.
+
+---
+
+## Adopt
+
+Given:
+
+```text
+20260810120000_initial_indexes.rb
+```
+
+When:
+
+```bash
+bundle exec couchbaseorm index:adopt
+```
+
+Then:
+
+* version `20260810120000` is inserted into
+  `CouchbaseOrm::IndexSchemaMigration`;
+* no queries are executed against indexes.
+
+---
+
+# V1 Complete
+
+Supported:
+
+* existing cluster introspection;
+* migration generation;
+* deterministic output;
+* deferred index creation;
+* single BUILD INDEX operation;
+* rollback support;
+* production adoption.
+
+Not Supported:
+
+* scopes and collections;
+* primary indexes;
+* index diff;
+* index status;
+* multiple buckets;
+* schema dump;
+* automatic synchronization.
+
+The implementation intentionally focuses on enabling existing production clusters to adopt CouchbaseORM index migrations with minimal risk and maximum simplicity.

--- a/specs/004-add-initial-index-migration-generation/spec.md
+++ b/specs/004-add-initial-index-migration-generation/spec.md
@@ -1,0 +1,294 @@
+# Spec: Initial Index Migration Generation
+
+## Motivation
+
+Many existing Couchbase clusters already contain a large number of indexes created manually over time.
+
+When adopting CouchbaseORM index migrations, users should be able to bootstrap their migration history from the indexes already present in production.
+
+This allows:
+
+* creating new environments (development, staging) with the same indexes as production;
+* versioning existing indexes;
+* progressively adopting index migrations without recreating production indexes.
+
+---
+
+# Goals
+
+* Generate an initial migration from existing indexes.
+* Support gradual adoption of index migrations.
+* Preserve existing production indexes.
+* Allow development and staging environments to recreate indexes from migrations.
+* Stay close to the Rails philosophy.
+
+---
+
+# Non-Goals
+
+* Synchronizing indexes automatically.
+* Comparing migration definitions with the cluster.
+* Updating existing indexes.
+* Detecting unused indexes.
+* Replacing future migrations.
+
+---
+
+# Command
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+Generates a migration representing the current state of indexes for the configured bucket.
+
+---
+
+# Generated Migration
+
+By default:
+
+```text
+db/indexes/
+  20260810120000_initial_indexes.rb
+```
+
+Example:
+
+```ruby
+class InitialIndexes < CouchbaseOrm::IndexMigration
+  def up
+    add_index(
+      :date_on_type,
+      keys: [:date],
+      where: "type is valued and date is valued",
+      defer_build: true
+    )
+
+    add_index(
+      :type_company,
+      keys: [:type, :company_id],
+      where: "type is valued and company_id is valued",
+      defer_build: true
+    )
+
+    add_index(
+      :type_company_external_ref_on_route,
+      keys: [:type, :company_id, :external_ref],
+      where: "type = 'route'",
+      defer_build: true
+    )
+
+    build_indexes(
+      :date_on_type,
+      :type_company,
+      :type_company_external_ref_on_route
+    )
+  end
+
+  def down
+    remove_index :type_company_external_ref_on_route
+    remove_index :type_company
+    remove_index :date_on_type
+  end
+end
+```
+
+---
+
+# Source
+
+Indexes are extracted from:
+
+```sql
+SELECT *
+FROM system:indexes
+WHERE keyspace_id = bucket_name
+```
+
+Only indexes belonging to the configured bucket are considered.
+
+Primary indexes are ignored.
+
+Indexes are ordered alphabetically by name to ensure deterministic output.
+
+---
+
+# Deferred Build
+
+All generated indexes use:
+
+```ruby
+defer_build: true
+```
+
+A single:
+
+```ruby
+build_indexes(...)
+```
+
+statement is generated after all indexes.
+
+This minimizes rebuild time when creating new environments.
+
+---
+
+# Migration Name
+
+Default:
+
+```text
+InitialIndexes
+```
+
+Custom name:
+
+```bash
+bundle exec couchbaseorm index:dump NAME=FleetIndexes
+```
+
+Generates:
+
+```ruby
+class FleetIndexes < CouchbaseOrm::IndexMigration
+end
+```
+
+---
+
+# Production Adoption
+
+After generating the migration, production users may mark it as executed without creating indexes again.
+
+Example:
+
+```bash
+bundle exec couchbaseorm index:adopt
+```
+
+This command inserts the migration version into:
+
+```ruby
+CouchbaseOrm::IndexSchemaMigration
+```
+
+without executing the migration.
+
+No indexes are created or modified.
+
+---
+
+# Development and Staging
+
+In development or staging:
+
+```bash
+bundle exec couchbaseorm index:migrate
+```
+
+creates all indexes defined by the generated migration.
+
+This ensures environments have the same index structure as production.
+
+---
+
+# Acceptance Criteria
+
+## Dump Existing Indexes
+
+Given a bucket containing:
+
+* date_on_type
+* type_company
+* type_company_external_ref_on_route
+
+When:
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+Then:
+
+* an initial migration file is created;
+* all indexes are represented with `add_index`;
+* indexes are sorted by name.
+
+---
+
+## Primary Indexes
+
+Given a primary index exists,
+
+When:
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+Then the primary index is ignored.
+
+---
+
+## Deferred Build
+
+Generated indexes contain:
+
+```ruby
+defer_build: true
+```
+
+and a single:
+
+```ruby
+build_indexes(...)
+```
+
+statement is generated.
+
+---
+
+## Deterministic Output
+
+Running:
+
+```bash
+bundle exec couchbaseorm index:dump
+```
+
+multiple times without cluster changes produces identical migration contents.
+
+---
+
+## Production Adoption
+
+Given the initial migration exists,
+
+When:
+
+```bash
+bundle exec couchbaseorm index:adopt
+```
+
+is executed,
+
+Then:
+
+* the migration version is marked as executed;
+* no indexes are created;
+* no indexes are removed.
+
+---
+
+# Future Extensions
+
+Possible future additions:
+
+* `index:diff`
+* `index:status`
+* `index:cleanup`
+* support for scopes and collections
+* support for primary indexes
+* schema dump (`db/index_schema.rb`)
+* import from multiple buckets


### PR DESCRIPTION
# Spec: Initial Index Migration Generation

## Motivation

Many existing Couchbase clusters already contain a large number of indexes created manually over time.

When adopting CouchbaseORM index migrations, users should be able to bootstrap their migration history from the indexes already present in production.

This allows:

* creating new environments (development, staging) with the same indexes as production;
* versioning existing indexes;
* progressively adopting index migrations without recreating production indexes.

---

# Goals

* Generate an initial migration from existing indexes.
* Support gradual adoption of index migrations.
* Preserve existing production indexes.
* Allow development and staging environments to recreate indexes from migrations.
* Stay close to the Rails philosophy.

---

# Non-Goals

* Synchronizing indexes automatically.
* Comparing migration definitions with the cluster.
* Updating existing indexes.
* Detecting unused indexes.
* Replacing future migrations.

---

# Command

```bash
bundle exec couchbaseorm index:dump
```

Generates a migration representing the current state of indexes for the configured bucket.

---

# Generated Migration

By default:

```text
db/indexes/
  20260810120000_initial_indexes.rb
```

Example:

```ruby
class InitialIndexes < CouchbaseOrm::IndexMigration
  def up
    add_index(
      :date_on_type,
      keys: [:date],
      where: "type is valued and date is valued",
      defer_build: true
    )

    add_index(
      :type_company,
      keys: [:type, :company_id],
      where: "type is valued and company_id is valued",
      defer_build: true
    )

    add_index(
      :type_company_external_ref_on_route,
      keys: [:type, :company_id, :external_ref],
      where: "type = 'route'",
      defer_build: true
    )

    build_indexes(
      :date_on_type,
      :type_company,
      :type_company_external_ref_on_route
    )
  end

  def down
    remove_index :type_company_external_ref_on_route
    remove_index :type_company
    remove_index :date_on_type
  end
end
```

---

# Source

Indexes are extracted from:

```sql
SELECT *
FROM system:indexes
WHERE keyspace_id = bucket_name
```

Only indexes belonging to the configured bucket are considered.

Primary indexes are ignored.

Indexes are ordered alphabetically by name to ensure deterministic output.

---

# Deferred Build

All generated indexes use:

```ruby
defer_build: true
```

A single:

```ruby
build_indexes(...)
```

statement is generated after all indexes.

This minimizes rebuild time when creating new environments.

---

# Migration Name

Default:

```text
InitialIndexes
```

Custom name:

```bash
bundle exec couchbaseorm index:dump NAME=FleetIndexes
```

Generates:

```ruby
class FleetIndexes < CouchbaseOrm::IndexMigration
end
```

---

# Production Adoption

After generating the migration, production users may mark it as executed without creating indexes again.

Example:

```bash
bundle exec couchbaseorm index:adopt
```

This command inserts the migration version into:

```ruby
CouchbaseOrm::IndexSchemaMigration
```

without executing the migration.

No indexes are created or modified.

---

# Development and Staging

In development or staging:

```bash
bundle exec couchbaseorm index:migrate
```

creates all indexes defined by the generated migration.

This ensures environments have the same index structure as production.

---

# Acceptance Criteria

## Dump Existing Indexes

Given a bucket containing:

* date_on_type
* type_company
* type_company_external_ref_on_route

When:

```bash
bundle exec couchbaseorm index:dump
```

Then:

* an initial migration file is created;
* all indexes are represented with `add_index`;
* indexes are sorted by name.

---

## Primary Indexes

Given a primary index exists,

When:

```bash
bundle exec couchbaseorm index:dump
```

Then the primary index is ignored.

---

## Deferred Build

Generated indexes contain:

```ruby
defer_build: true
```

and a single:

```ruby
build_indexes(...)
```

statement is generated.

---

## Deterministic Output

Running:

```bash
bundle exec couchbaseorm index:dump
```

multiple times without cluster changes produces identical migration contents.

---

## Production Adoption

Given the initial migration exists,

When:

```bash
bundle exec couchbaseorm index:adopt
```

is executed,

Then:

* the migration version is marked as executed;
* no indexes are created;
* no indexes are removed.

---

# Future Extensions

Possible future additions:

* `index:diff`
* `index:status`
* `index:cleanup`
* support for scopes and collections
* support for primary indexes
* schema dump (`db/index_schema.rb`)
* import from multiple buckets
