### PR TITLE
add index schema dump and load

### DIFF
--- a/docs/reference/configuration.txt
+++ b/docs/reference/configuration.txt
@@ -29,6 +29,7 @@ named "dev_bucket".
       bucket: dev_bucket
       index:
         migrations_path: db/indexes
+        schema_path: db/index_schema.rb
         num_replica: 0
 
     test:
@@ -43,6 +44,7 @@ named "dev_bucket".
       password: <%= ENV['COUCHBASE_PASSWORD'] %>
       index:
         bucket: <%= ENV['COUCHBASE_INDEX_BUCKET'] %>
+        schema_path: <%= ENV['COUCHBASE_INDEX_SCHEMA_PATH'] %>
         num_replica: 1
 
 The top level key in the configuration file, ``development`` in the above
@@ -51,7 +53,7 @@ i.e. ``development``, ``test`` or ``production``.
 
 Index migration settings for Rails applications may also be configured in the
 nested ``index`` section. Supported keys are ``bucket``, ``migrations_path``
-and ``num_replica``.
+``schema_path``, and ``num_replica``.
 
 When ``index.bucket`` is omitted, CouchbaseOrm uses the top-level connection
 ``bucket`` as the default index bucket.
@@ -96,6 +98,12 @@ loads.
 
 For index migrations, Rails loads the same ``config/couchbase.yml`` entry and
 applies nested ``index`` values after connection settings are loaded.
+
+The ``index.schema_path`` value controls where schema snapshot commands read and
+write index state:
+
+* ``bundle exec couchbaseorm index:schema:dump`` writes the schema file.
+* ``bundle exec couchbaseorm index:schema:load`` loads indexes from the schema file.
 
 ERb Preprocessing
 =================

--- a/docs/reference/index-migrations.txt
+++ b/docs/reference/index-migrations.txt
@@ -32,6 +32,7 @@ Rails applications can configure index migration options in
 
     index:
       migrations_path: custom/indexes
+      schema_path: custom/index_schema.rb
       num_replica: 1
 
 The index bucket defaults to the top-level ``bucket`` unless ``index.bucket``
@@ -45,6 +46,7 @@ You can also configure or override index migration options in Ruby with
   CouchbaseOrm.configure do |config|
     config.index.bucket = 'fleet-prod'
     config.index.migrations_path = 'db/indexes'
+    config.index.schema_path = 'db/index_schema.rb'
     config.index.num_replica = 1
   end
 
@@ -65,6 +67,10 @@ Supported options:
    * - ``migrations_path``
      - ``db/indexes``
      - Directory used to load and generate index migration files.
+
+   * - ``schema_path``
+     - ``db/index_schema.rb``
+     - Path used to read and write the index schema snapshot.
 
    * - ``num_replica``
      - ``0``
@@ -318,6 +324,22 @@ Show migration status:
 .. code-block:: bash
 
   bundle exec couchbaseorm index:status
+
+Schema dump and load:
+
+.. code-block:: bash
+
+  bundle exec couchbaseorm index:schema:dump
+  bundle exec couchbaseorm index:schema:load
+
+``index:schema:dump`` replays migrations in memory and writes the current index
+state to ``db/index_schema.rb`` (or ``index.schema_path`` when configured).
+
+``index:schema:load`` applies indexes from the schema file directly, without
+replaying migration files.
+
+During schema load, indexes declared with ``defer_build: true`` are collected
+and built automatically in a single ``BUILD INDEX`` statement.
 
 Example status output:
 

--- a/lib/couchbase-orm.rb
+++ b/lib/couchbase-orm.rb
@@ -12,6 +12,7 @@ end
 module CouchbaseOrm
   autoload :Configuration, 'couchbase-orm/configuration'
   autoload :IndexMigration, 'couchbase-orm/index_migration'
+  autoload :IndexSchema, 'couchbase-orm/index_schema'
   autoload :IndexMigrationContext, 'couchbase-orm/index_migration_context'
   autoload :IndexMigrator, 'couchbase-orm/index_migrator'
   autoload :IndexSchemaMigration, 'couchbase-orm/index_schema_migration'

--- a/lib/couchbase-orm/configuration.rb
+++ b/lib/couchbase-orm/configuration.rb
@@ -3,12 +3,13 @@
 module CouchbaseOrm
   class Configuration
     class Index
-      attr_accessor :bucket, :num_replica, :migrations_path
+      attr_accessor :bucket, :num_replica, :migrations_path, :schema_path
 
       def initialize
         @bucket = nil
         @num_replica = 0
         @migrations_path = 'db/indexes'
+        @schema_path = 'db/index_schema.rb'
       end
 
       def effective_bucket

--- a/lib/couchbase-orm/index_config_loader.rb
+++ b/lib/couchbase-orm/index_config_loader.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 
 module CouchbaseOrm
   class IndexConfigLoader
-    SUPPORTED_KEYS = %i[bucket migrations_path num_replica].freeze
+    SUPPORTED_KEYS = %i[bucket migrations_path schema_path num_replica].freeze
 
     def self.apply(config_hash)
       config_hash = config_hash.with_indifferent_access

--- a/lib/couchbase-orm/index_migration.rb
+++ b/lib/couchbase-orm/index_migration.rb
@@ -13,17 +13,18 @@ module CouchbaseOrm
 
     module Operations
       class AddIndex
-        attr_reader :name, :keys, :where, :defer_build
+        attr_reader :name, :keys, :where, :num_replica, :defer_build
 
-        def initialize(name, keys:, where: nil, defer_build: false)
+        def initialize(name, keys:, where: nil, num_replica: nil, defer_build: false)
           @name = name
           @keys = keys
           @where = where
+          @num_replica = num_replica
           @defer_build = defer_build
         end
 
         def execute(migration)
-          migration.execute_add_index(name, keys: keys, where: where, defer_build: defer_build)
+          migration.execute_add_index(name, keys: keys, where: where, num_replica: num_replica, defer_build: defer_build)
         end
 
         def inverse
@@ -124,7 +125,7 @@ module CouchbaseOrm
         @config = config
       end
 
-      def add_index(name, keys:, where: nil, defer_build: false)
+      def add_index(name, keys:, where: nil, num_replica: nil, defer_build: false)
         bucket = @config.effective_bucket
         raise ArgumentError.new('Missing index bucket configuration') if bucket.to_s.strip.empty?
         raise ArgumentError.new('Missing index keys configuration') if Array(keys).empty?
@@ -132,7 +133,7 @@ module CouchbaseOrm
         query = +"CREATE INDEX `#{name}`\n"
         query << "ON `#{bucket}`(#{Array(keys).map { |key| "`#{key}`" }.join(',')})"
         query << "\nWHERE (#{where})" if where
-        options = with_options(defer_build: defer_build)
+        options = with_options(defer_build: defer_build, num_replica: num_replica)
         query << "\nWITH #{JSON.pretty_generate(options)}" unless options.empty?
         query
       end
@@ -157,10 +158,11 @@ module CouchbaseOrm
 
       private
 
-      def with_options(defer_build:)
+      def with_options(defer_build:, num_replica:)
         options = {}
         options['defer_build'] = true if defer_build
-        options['num_replica'] = @config.num_replica unless @config.num_replica.nil?
+        effective_num_replica = num_replica.nil? ? @config.num_replica : num_replica
+        options['num_replica'] = effective_num_replica unless effective_num_replica.nil?
         options
       end
     end
@@ -176,8 +178,8 @@ module CouchbaseOrm
       end
     end
 
-    def add_index(name, keys:, where: nil, defer_build: false)
-      execute_operation(Operations::AddIndex.new(name, keys: keys, where: where, defer_build: defer_build))
+    def add_index(name, keys:, where: nil, num_replica: nil, defer_build: false)
+      execute_operation(Operations::AddIndex.new(name, keys: keys, where: where, num_replica: num_replica, defer_build: defer_build))
     end
 
     def remove_index(name)
@@ -192,8 +194,8 @@ module CouchbaseOrm
       execute_operation(Operations::BuildIndexes.new(index_names, wait: options.fetch(:wait, false)))
     end
 
-    def execute_add_index(name, keys:, where: nil, defer_build: false)
-      execute_query(query_builder.add_index(name, keys: keys, where: where, defer_build: defer_build))
+    def execute_add_index(name, keys:, where: nil, num_replica: nil, defer_build: false)
+      execute_query(query_builder.add_index(name, keys: keys, where: where, num_replica: num_replica, defer_build: defer_build))
     end
 
     def execute_remove_index(name)

--- a/lib/couchbase-orm/index_schema.rb
+++ b/lib/couchbase-orm/index_schema.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module CouchbaseOrm
+  class IndexSchema
+    autoload :Definition, 'couchbase-orm/index_schema/definition'
+    autoload :Dumper, 'couchbase-orm/index_schema/dumper'
+    autoload :Loader, 'couchbase-orm/index_schema/loader'
+
+    class DSL
+      def initialize(definition)
+        @definition = definition
+      end
+
+      def add_index(name, keys:, where: nil, num_replica: nil, defer_build: false)
+        @definition.add_index(name, keys: keys, where: where, num_replica: num_replica, defer_build: defer_build)
+      end
+
+      def remove_index(name)
+        @definition.remove_index(name)
+      end
+
+      def rename_index(old_name, new_name)
+        @definition.rename_index(old_name, new_name)
+      end
+    end
+
+    class << self
+      def define(version: nil, &block)
+        definition = Definition.new
+        DSL.new(definition).instance_eval(&block) if block
+
+        if @define_handler
+          @define_handler.call(definition, version)
+        else
+          definition
+        end
+      end
+
+      def with_define_handler(handler)
+        previous_handler = @define_handler
+        @define_handler = handler
+        yield
+      ensure
+        @define_handler = previous_handler
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_schema/definition.rb
+++ b/lib/couchbase-orm/index_schema/definition.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module CouchbaseOrm
+  class IndexSchema
+    class Definition
+      attr_reader :indexes
+
+      def initialize
+        @indexes = {}
+      end
+
+      def add_index(name, keys:, where: nil, num_replica: nil, defer_build: false)
+        index_name = normalize_name(name)
+        definition = {
+          keys: normalize_keys(keys)
+        }
+
+        normalized_where = normalize_where(where)
+        definition[:where] = normalized_where if normalized_where
+        definition[:num_replica] = num_replica unless num_replica.nil?
+        definition[:defer_build] = true if defer_build
+
+        @indexes[index_name] = definition
+      end
+
+      def remove_index(name)
+        @indexes.delete(normalize_name(name))
+      end
+
+      def rename_index(old_name, new_name)
+        old_index_name = normalize_name(old_name)
+        new_index_name = normalize_name(new_name)
+
+        definition = @indexes.delete(old_index_name)
+        return unless definition
+
+        @indexes[new_index_name] = definition
+      end
+
+      private
+
+      def normalize_name(name)
+        name.to_sym
+      end
+
+      def normalize_keys(raw_keys)
+        Array(raw_keys).map { |key| normalize_key(key) }
+      end
+
+      def normalize_key(key)
+        return key if key.is_a?(Symbol)
+
+        value = key.to_s.strip
+        match = value.match(/\A`?([a-zA-Z_][a-zA-Z0-9_]*)`?\z/)
+        return match[1].to_sym if match
+
+        value
+      end
+
+      def normalize_where(where)
+        stripped = where.to_s.strip
+        stripped.empty? ? nil : stripped
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_schema/dumper.rb
+++ b/lib/couchbase-orm/index_schema/dumper.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module CouchbaseOrm
+  class IndexSchema
+    class Dumper
+      def initialize(context: CouchbaseOrm::IndexMigrationContext.new, path: CouchbaseOrm.config.index.schema_path)
+        @context = context
+        @path = path
+      end
+
+      def dump
+        definition = Definition.new
+        migrations = @context.migrations
+
+        migrations.each do |migration_def|
+          replay_migration(migration_def, definition)
+        end
+
+        schema_source = source_for(definition, version: migrations.max_by(&:version)&.version)
+
+        FileUtils.mkdir_p(File.dirname(@path))
+        File.write(@path, schema_source)
+        @path
+      end
+
+      def source_for(definition, version: nil)
+        lines = []
+        lines << definition_header(version)
+
+        index_names = definition.indexes.keys.sort
+        index_names.each_with_index do |name, index|
+          lines.concat(index_lines(name, definition.indexes[name]))
+          lines << '' unless index == index_names.length - 1
+        end
+
+        lines << 'end'
+        "#{lines.join("\n")}\n"
+      end
+
+      private
+
+      def replay_migration(migration_def, definition)
+        migration = migration_def.klass.new
+
+        migration.singleton_class.class_eval do
+          define_method(:add_index) do |name, keys:, where: nil, num_replica: nil, defer_build: false|
+            definition.add_index(name, keys: keys, where: where, num_replica: num_replica, defer_build: defer_build)
+          end
+
+          define_method(:remove_index) do |name|
+            definition.remove_index(name)
+          end
+
+          define_method(:rename_index) do |old_name, new_name|
+            definition.rename_index(old_name, new_name)
+          end
+
+          define_method(:build_indexes) do |*_index_names, **_options|
+            nil
+          end
+        end
+
+        migration.migrate(:up)
+      end
+
+      def definition_header(version)
+        if version
+          "CouchbaseOrm::IndexSchema.define(version: #{version}) do"
+        else
+          'CouchbaseOrm::IndexSchema.define do'
+        end
+      end
+
+      def index_lines(name, options)
+        lines = ["  add_index :#{name},"]
+
+        option_lines = ["keys: #{ruby_array(options[:keys])}"]
+        option_lines << "where: #{options[:where].inspect}" if options.key?(:where)
+        option_lines << "num_replica: #{options[:num_replica]}" if options.key?(:num_replica)
+        option_lines << 'defer_build: true' if options[:defer_build]
+
+        option_lines.each_with_index do |line, index|
+          suffix = index == option_lines.length - 1 ? '' : ','
+          lines << "    #{line}#{suffix}"
+        end
+
+        lines
+      end
+
+      def ruby_array(values)
+        "[#{Array(values).map { |value| ruby_value(value) }.join(', ')}]"
+      end
+
+      def ruby_value(value)
+        value.is_a?(Symbol) ? ":#{value}" : value.inspect
+      end
+    end
+  end
+end

--- a/lib/couchbase-orm/index_schema/loader.rb
+++ b/lib/couchbase-orm/index_schema/loader.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module CouchbaseOrm
+  class IndexSchema
+    class Loader
+      def initialize(path: CouchbaseOrm.config.index.schema_path, migration_class: CouchbaseOrm::IndexMigration)
+        @path = path
+        @migration_class = migration_class
+      end
+
+      def load
+        definition, version = read_definition
+        apply_definition(definition)
+        version
+      end
+
+      private
+
+      def read_definition
+        captured_definition = nil
+        captured_version = nil
+
+        CouchbaseOrm::IndexSchema.with_define_handler(lambda do |definition, version|
+          captured_definition = definition
+          captured_version = version
+        end) do
+          Kernel.load(File.expand_path(@path))
+        end
+
+        raise ArgumentError.new("Schema file did not define CouchbaseOrm::IndexSchema: #{@path}") unless captured_definition
+
+        [captured_definition, captured_version]
+      rescue Errno::ENOENT
+        raise ArgumentError.new("Schema file not found: #{@path}")
+      end
+
+      def apply_definition(definition)
+        migration = @migration_class.new
+        deferred_indexes = []
+
+        definition.indexes.keys.sort.each do |name|
+          options = definition.indexes[name]
+          migration.execute_add_index(
+            name,
+            keys: options[:keys],
+            where: options[:where],
+            num_replica: options[:num_replica],
+            defer_build: options.fetch(:defer_build, false)
+          )
+          deferred_indexes << name if options[:defer_build]
+        end
+
+        migration.execute_build_indexes(deferred_indexes.sort) if deferred_indexes.any?
+      end
+    end
+  end
+end

--- a/spec/index_config_loader_spec.rb
+++ b/spec/index_config_loader_spec.rb
@@ -30,6 +30,17 @@ describe CouchbaseOrm::IndexConfigLoader do
     expect(CouchbaseOrm.config.index.num_replica).to eq(1)
   end
 
+  it 'loads schema_path from nested index config' do
+    described_class.apply(
+      bucket: 'fleet-dev',
+      index: {
+        schema_path: 'custom/index_schema.rb'
+      }
+    )
+
+    expect(CouchbaseOrm.config.index.schema_path).to eq('custom/index_schema.rb')
+  end
+
   it 'defaults index bucket to connection bucket from top-level config' do
     described_class.apply(bucket: 'fleet-dev')
 
@@ -51,6 +62,7 @@ describe CouchbaseOrm::IndexConfigLoader do
     described_class.apply(bucket: 'fleet-dev')
 
     expect(CouchbaseOrm.config.index.migrations_path).to eq('db/indexes')
+    expect(CouchbaseOrm.config.index.schema_path).to eq('db/index_schema.rb')
     expect(CouchbaseOrm.config.index.num_replica).to eq(0)
   end
 

--- a/spec/index_migration_spec.rb
+++ b/spec/index_migration_spec.rb
@@ -48,6 +48,22 @@ describe CouchbaseOrm::IndexMigration do
       SQL
     end
 
+    it 'builds create index query with explicit num_replica override' do
+      query = described_class.new.add_index(
+        :type_company,
+        keys: %i[type company_id],
+        num_replica: 3
+      )
+
+      expect(query).to eq(<<~SQL.strip)
+        CREATE INDEX `type_company`
+        ON `fleet-prod`(`type`,`company_id`)
+        WITH {
+          "num_replica": 3
+        }
+      SQL
+    end
+
     it 'builds build indexes query' do
       query = described_class.new.build_indexes(%i[type_company date_on_type])
 

--- a/spec/index_schema_definition_spec.rb
+++ b/spec/index_schema_definition_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+
+describe CouchbaseOrm::IndexSchema::Definition do
+  it 'tracks add_index, remove_index and rename_index operations' do
+    definition = described_class.new
+
+    definition.add_index(:type_company, keys: %i[type company_id])
+    definition.add_index(:date_on_type, keys: [:date], where: 'type is valued', defer_build: true)
+
+    expect(definition.indexes).to eq(
+      type_company: {
+        keys: %i[type company_id]
+      },
+      date_on_type: {
+        keys: [:date],
+        where: 'type is valued',
+        defer_build: true
+      }
+    )
+
+    definition.remove_index(:type_company)
+    definition.rename_index(:date_on_type, :date_on_type_v2)
+
+    expect(definition.indexes).to eq(
+      date_on_type_v2: {
+        keys: [:date],
+        where: 'type is valued',
+        defer_build: true
+      }
+    )
+  end
+end

--- a/spec/index_schema_dumper_spec.rb
+++ b/spec/index_schema_dumper_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+require 'tmpdir'
+
+describe CouchbaseOrm::IndexSchema::Dumper do
+  it 'replays migrations in memory and writes deterministic schema output' do
+    Dir.mktmpdir do |dir|
+      migrations_path = File.join(dir, 'indexes')
+      schema_path = File.join(dir, 'index_schema.rb')
+      write_migrations(migrations_path)
+
+      context = CouchbaseOrm::IndexMigrationContext.new(path: migrations_path)
+      dumper = described_class.new(context: context, path: schema_path)
+
+      first_dump_path = dumper.dump
+      first_dump = File.read(first_dump_path)
+
+      second_dump_path = dumper.dump
+      second_dump = File.read(second_dump_path)
+
+      expect(first_dump).to eq(second_dump)
+      expect(first_dump).to include('CouchbaseOrm::IndexSchema.define(version: 20260101120000) do')
+      expect(first_dump).to include("add_index :date_on_type,\n    keys: [:date],\n    defer_build: true")
+      expect(first_dump).to include("add_index :type_company,\n    keys: [:type, :company_id],\n    where: \"type is valued and company_id is valued\",\n    num_replica: 2")
+      expect(first_dump).not_to include('remove_index')
+    end
+  end
+
+  def write_migrations(migrations_path)
+    FileUtils.mkdir_p(migrations_path)
+
+    File.write(
+      File.join(migrations_path, '20260101110000_add_type_company_index.rb'),
+      <<~RUBY
+        class AddTypeCompanyIndex < CouchbaseOrm::IndexMigration
+          def change
+            add_index :type_company,
+              keys: [:company_id, :type]
+          end
+        end
+      RUBY
+    )
+
+    File.write(
+      File.join(migrations_path, '20260101120000_replace_type_company_index.rb'),
+      <<~RUBY
+        class ReplaceTypeCompanyIndex < CouchbaseOrm::IndexMigration
+          def up
+            remove_index :type_company
+
+            add_index :type_company,
+              keys: [:type, :company_id],
+              where: "type is valued and company_id is valued",
+              num_replica: 2
+
+            add_index :date_on_type,
+              keys: [:date],
+              defer_build: true
+          end
+        end
+      RUBY
+    )
+  end
+end

--- a/spec/index_schema_loader_spec.rb
+++ b/spec/index_schema_loader_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require File.expand_path('support', __dir__)
+require 'tmpdir'
+
+describe CouchbaseOrm::IndexSchema::Loader do
+  let(:schema_source) do
+    <<~RUBY
+      CouchbaseOrm::IndexSchema.define(version: 20260101120000) do
+        add_index :type_company,
+          keys: [:type],
+          defer_build: true
+
+        add_index :date_on_type,
+          keys: [:date],
+          defer_build: true
+      end
+    RUBY
+  end
+
+  before do
+    CouchbaseOrm.reset_config!
+    CouchbaseOrm.configure do |config|
+      config.index.bucket = 'fleet-prod'
+      config.index.num_replica = 0
+    end
+  end
+
+  it 'loads schema file and creates indexes without replaying migrations' do
+    Dir.mktmpdir do |dir|
+      migrations_path = File.join(dir, 'indexes')
+      schema_path = File.join(dir, 'index_schema.rb')
+      FileUtils.mkdir_p(migrations_path)
+
+      File.write(
+        File.join(migrations_path, '20260101110000_should_not_be_loaded.rb'),
+        "raise 'index migration files should not be loaded by index:schema:load'\n"
+      )
+      File.write(schema_path, schema_source)
+
+      CouchbaseOrm.configure do |config|
+        config.index.migrations_path = migrations_path
+      end
+
+      cluster = instance_double(Couchbase::Cluster)
+      allow(CouchbaseOrm::Connection).to receive(:cluster).and_return(cluster)
+
+      expect_schema_load_queries(cluster)
+
+      version = described_class.new(path: schema_path).load
+
+      expect(version).to eq(20260101120000)
+    end
+  end
+
+  def expect_schema_load_queries(cluster)
+    expect(cluster).to receive(:query).with(/CREATE INDEX `date_on_type`/, instance_of(Couchbase::Options::Query)).ordered
+    expect(cluster).to receive(:query).with(/CREATE INDEX `type_company`/, instance_of(Couchbase::Options::Query)).ordered
+    expect(cluster).to receive(:query).with(<<~SQL.strip, instance_of(Couchbase::Options::Query)).ordered
+      BUILD INDEX ON `fleet-prod`
+      (
+        `date_on_type`,
+        `type_company`
+      );
+    SQL
+  end
+end

--- a/specs/005-add-index-schema-dump-and-load/plan.md
+++ b/specs/005-add-index-schema-dump-and-load/plan.md
@@ -1,0 +1,445 @@
+# Implementation Plan: Index Schema Dump and Load
+
+## Goal
+
+Introduce:
+
+```bash
+bundle exec couchbaseorm index:schema:dump
+bundle exec couchbaseorm index:schema:load
+```
+
+and the schema file:
+
+```text
+db/index_schema.rb
+```
+
+similar to ActiveRecord's:
+
+```text
+db/schema.rb
+```
+
+The schema file represents the current index state and avoids replaying the entire migration history for fresh installations.
+
+---
+
+# Phase 1 — Introduce IndexSchema
+
+## Goal
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexSchema
+```
+
+similar to:
+
+```ruby
+ActiveRecord::Schema
+```
+
+Support:
+
+```ruby
+CouchbaseOrm::IndexSchema.define(version: 20260101120000) do
+  add_index :type_company,
+    keys: [:type, :company_id]
+
+  add_index :date_on_type,
+    keys: [:date]
+end
+```
+
+---
+
+# Phase 2 — Introduce Schema Definition
+
+## Goal
+
+Represent the current index schema in memory.
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexSchema::Definition
+```
+
+Responsibilities:
+
+```ruby
+add_index
+remove_index
+rename_index
+```
+
+Example:
+
+```ruby
+definition.indexes
+```
+
+returns:
+
+```ruby
+{
+  type_company: {
+    keys: [:type, :company_id]
+  },
+
+  date_on_type: {
+    keys: [:date]
+  }
+}
+```
+
+---
+
+# Phase 3 — Replay Migrations In Memory
+
+## Goal
+
+Compute the final schema.
+
+Load:
+
+```text
+db/indexes/*.rb
+```
+
+Replay operations against:
+
+```ruby
+IndexSchema::Definition
+```
+
+Supported operations:
+
+```ruby
+add_index
+remove_index
+rename_index
+```
+
+Ignored:
+
+```ruby
+build_indexes
+```
+
+because build operations do not affect schema state.
+
+---
+
+# Phase 4 — Generate index_schema.rb
+
+## Goal
+
+Create:
+
+```text
+db/index_schema.rb
+```
+
+Example:
+
+```ruby
+CouchbaseOrm::IndexSchema.define(version: 20260101120000) do
+  add_index :type_company,
+    keys: [:type, :company_id]
+
+  add_index :date_on_type,
+    keys: [:date]
+end
+```
+
+Preserve:
+
+```ruby
+keys
+where
+num_replica
+defer_build
+```
+
+Output should be deterministic and sorted by index name.
+
+---
+
+# Phase 5 — Introduce Schema Dumper
+
+## Goal
+
+Encapsulate schema generation.
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexSchema::Dumper
+```
+
+Responsibilities:
+
+```ruby
+dump
+```
+
+Workflow:
+
+```text
+Load migrations
+↓
+Replay in memory
+↓
+Build Definition
+↓
+Generate Ruby DSL
+↓
+Write db/index_schema.rb
+```
+
+---
+
+# Phase 6 — Add index:schema:dump Task
+
+## Goal
+
+Expose:
+
+```bash
+bundle exec couchbaseorm index:schema:dump
+```
+
+Behavior:
+
+```text
+Load migrations
+↓
+Compute final schema
+↓
+Generate db/index_schema.rb
+```
+
+No database access is required.
+
+---
+
+# Phase 7 — Schema Loader
+
+## Goal
+
+Load schema directly.
+
+Create:
+
+```ruby
+CouchbaseOrm::IndexSchema::Loader
+```
+
+Responsibilities:
+
+```ruby
+load
+```
+
+Workflow:
+
+```text
+Load db/index_schema.rb
+↓
+Execute add_index operations
+↓
+Collect deferred indexes
+↓
+Execute BUILD INDEX
+```
+
+Migration files are not loaded.
+
+---
+
+# Phase 8 — Add index:schema:load Task
+
+## Goal
+
+Expose:
+
+```bash
+bundle exec couchbaseorm index:schema:load
+```
+
+Behavior:
+
+```text
+Load db/index_schema.rb
+↓
+Create indexes
+↓
+Build deferred indexes
+```
+
+No migration replay occurs.
+
+---
+
+# Phase 9 — Schema Version
+
+## Goal
+
+Preserve schema version.
+
+Generated file:
+
+```ruby
+CouchbaseOrm::IndexSchema.define(
+  version: 20260101120000
+) do
+  ...
+end
+```
+
+Version corresponds to the latest migration version.
+
+Similar to:
+
+```ruby
+ActiveRecord::Schema.define(version: ...)
+```
+
+---
+
+# Phase 10 — Tests
+
+## Definition
+
+Verify:
+
+```ruby
+add_index
+remove_index
+rename_index
+```
+
+correctly update:
+
+```ruby
+definition.indexes
+```
+
+---
+
+## Dump
+
+Given:
+
+```ruby
+add_index :type_company,
+  keys: [:company_id, :type]
+
+remove_index :type_company
+
+add_index :type_company,
+  keys: [:type, :company_id]
+```
+
+Expect:
+
+```ruby
+index_schema.rb
+```
+
+contains:
+
+```ruby
+add_index :type_company,
+  keys: [:type, :company_id]
+```
+
+and no intermediate operations.
+
+---
+
+## Load
+
+Given:
+
+```ruby
+CouchbaseOrm::IndexSchema.define do
+  add_index :type_company,
+    keys: [:type, :company_id]
+end
+```
+
+Expect:
+
+```bash
+bundle exec couchbaseorm index:schema:load
+```
+
+to create the index without loading migration files.
+
+---
+
+## Deferred indexes
+
+Given:
+
+```ruby
+add_index :type_company,
+  keys: [:type],
+  defer_build: true
+
+add_index :date_on_type,
+  keys: [:date],
+  defer_build: true
+```
+
+Expect:
+
+```ruby
+build_indexes(
+  :date_on_type,
+  :type_company
+)
+```
+
+to be executed automatically during schema loading.
+
+---
+
+## Deterministic output
+
+Running:
+
+```bash
+bundle exec couchbaseorm index:schema:dump
+```
+
+twice without migration changes should produce identical files.
+
+---
+
+# V1 Complete
+
+Supported:
+
+* `index:schema:dump`
+* `index:schema:load`
+* `db/index_schema.rb`
+* in-memory migration replay
+* deterministic schema generation
+* schema version
+* deferred index build during schema load
+
+Not supported:
+
+* comparison with `system:indexes`
+* dry-run mode
+* comments
+* scopes and collections
+* metadata
+* `index:schema:diff`
+
+The design intentionally mirrors ActiveRecord's `schema.rb` and `db:schema:load` philosophy.

--- a/specs/005-add-index-schema-dump-and-load/spec.md
+++ b/specs/005-add-index-schema-dump-and-load/spec.md
@@ -1,0 +1,401 @@
+# Spec: Index Schema Dump and Load
+
+## Motivation
+
+Over time, index migrations accumulate:
+
+```text id="mzkd9r"
+db/indexes/
+
+20250101000000_initial_indexes.rb
+20250102000000_add_route_indexes.rb
+20250103000000_add_workflow_indexes.rb
+20250104000000_change_company_index.rb
+...
+```
+
+Replaying every migration becomes increasingly expensive for fresh installations.
+
+ActiveRecord solves this problem with:
+
+```text id="tyk4i6"
+db/schema.rb
+```
+
+which represents the current database state independently from migration history.
+
+CouchbaseORM should provide the same capability for indexes.
+
+---
+
+# Goals
+
+* Provide a snapshot of the current index schema.
+* Speed up fresh installations.
+* Preserve migration history.
+* Stay close to ActiveRecord.
+* Keep migrations as the source of truth.
+
+---
+
+# Non-Goals
+
+* Rewriting migration history.
+* Automatic compaction.
+* Comparing against `system:indexes`.
+* Removing old migrations.
+* Replacing index migrations.
+
+---
+
+# Commands
+
+## Dump schema
+
+```bash id="wxwklv"
+bundle exec couchbaseorm index:schema:dump
+```
+
+Generates:
+
+```text id="pjwdix"
+db/index_schema.rb
+```
+
+---
+
+## Load schema
+
+```bash id="l6tkhg"
+bundle exec couchbaseorm index:schema:load
+```
+
+Loads all indexes defined in:
+
+```text id="7jbv5k"
+db/index_schema.rb
+```
+
+without replaying historical migrations.
+
+---
+
+# Schema File
+
+Default location:
+
+```text id="17oqyj"
+db/index_schema.rb
+```
+
+Example:
+
+```ruby id="qj5dvf"
+CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
+  add_index :type_company,
+    keys: [:type, :company_id],
+    where: "type is valued and company_id is valued"
+
+  add_index :date_on_type,
+    keys: [:date]
+
+  add_index :workflow_by_company,
+    keys: [:company_id],
+    where: "type = 'workflow'"
+end
+```
+
+---
+
+# Schema Version
+
+The schema stores the latest migration version:
+
+```ruby id="u22owj"
+version: 2026_01_01_120000
+```
+
+similar to:
+
+```ruby id="u6lbwy"
+ActiveRecord::Schema.define(version: ...)
+```
+
+---
+
+# IndexSchema DSL
+
+Introduce:
+
+```ruby id="b4obva"
+CouchbaseOrm::IndexSchema
+```
+
+Example:
+
+```ruby id="r9snbn"
+CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
+  add_index :type_company,
+    keys: [:type, :company_id]
+
+  add_index :date_on_type,
+    keys: [:date]
+end
+```
+
+The DSL supports:
+
+```ruby id="j9n2g9"
+add_index
+```
+
+---
+
+# Schema Dump
+
+## Behavior
+
+`index:schema:dump`:
+
+1. Loads all migrations.
+2. Replays them in memory.
+3. Computes the final schema.
+4. Generates:
+
+```text id="pdikzq"
+db/index_schema.rb
+```
+
+The generated schema contains only indexes that currently exist.
+
+Intermediate operations are discarded.
+
+---
+
+## Example
+
+Migrations:
+
+```ruby id="5gohgq"
+add_index :type_company,
+  keys: [:company_id, :type]
+
+remove_index :type_company
+
+add_index :type_company,
+  keys: [:type, :company_id]
+```
+
+Generated schema:
+
+```ruby id="95nr5m"
+CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
+  add_index :type_company,
+    keys: [:type, :company_id]
+end
+```
+
+---
+
+# Schema Load
+
+## Behavior
+
+`index:schema:load`:
+
+1. Loads:
+
+```text id="k0myly"
+db/index_schema.rb
+```
+
+2. Executes:
+
+```ruby id="a6n8vc"
+add_index
+```
+
+operations.
+
+3. Builds the indexes.
+
+No migration files are replayed.
+
+---
+
+# Build Behavior
+
+Indexes with:
+
+```ruby id="gx9sx2"
+defer_build: true
+```
+
+are collected and built together:
+
+```ruby id="uwv48h"
+build_indexes(
+  :type_company,
+  :date_on_type
+)
+```
+
+This behavior is internal to schema loading.
+
+---
+
+# Internal Representation
+
+Introduce:
+
+```ruby id="sq97sj"
+CouchbaseOrm::IndexSchema::Definition
+```
+
+Responsibilities:
+
+```ruby id="x9h4da"
+add_index
+remove_index
+rename_index
+```
+
+Example:
+
+```ruby id="zn4wbm"
+definition.indexes
+```
+
+returns:
+
+```ruby id="cjlwm6"
+{
+  type_company: {
+    keys: [:type, :company_id]
+  },
+
+  date_on_type: {
+    keys: [:date]
+  }
+}
+```
+
+---
+
+# Supported Operations
+
+Schema dump understands:
+
+```ruby id="9j1tyk"
+add_index
+remove_index
+rename_index
+```
+
+and preserves:
+
+```ruby id="13vmb7"
+keys
+where
+num_replica
+defer_build
+```
+
+---
+
+# Unsupported Operations
+
+Schema dump ignores:
+
+```ruby id="cc0m9x"
+build_indexes
+```
+
+because build operations are runtime concerns and do not affect schema state.
+
+---
+
+# Relationship with Migrations
+
+Migrations remain the source of truth.
+
+The schema file is a snapshot.
+
+Like ActiveRecord:
+
+```text id="b5pp4d"
+db/indexes/
+```
+
+contains history.
+
+```text id="vsl7cx"
+db/index_schema.rb
+```
+
+contains the current state.
+
+---
+
+# Acceptance Criteria
+
+### Dump
+
+Given:
+
+```ruby id="rnxg8c"
+add_index :type_company,
+  keys: [:company_id, :type]
+
+remove_index :type_company
+
+add_index :type_company,
+  keys: [:type, :company_id]
+```
+
+Then:
+
+```text id="n9tn7l"
+db/index_schema.rb
+```
+
+contains:
+
+```ruby id="h6cbg7"
+add_index :type_company,
+  keys: [:type, :company_id]
+```
+
+and no intermediate operations.
+
+---
+
+### Load
+
+Given:
+
+```text id="t8p3l0"
+db/index_schema.rb
+```
+
+Then:
+
+```bash id="k2gszk"
+bundle exec couchbaseorm index:schema:load
+```
+
+creates the indexes without replaying migration files.
+
+---
+
+# Future Extensions
+
+Possible future additions:
+
+* `index:schema:load:if_empty`
+* support for scopes and collections
+* `index:schema:dump --dry-run`
+* `index:schema:diff`
+* support for comments and metadata
+
+The design intentionally mirrors ActiveRecord's `schema.rb` and `db:schema:load` philosophy.


### PR DESCRIPTION
# Spec: Index Schema Dump and Load

## Motivation

Over time, index migrations accumulate:

```text id="mzkd9r"
db/indexes/

20250101000000_initial_indexes.rb
20250102000000_add_route_indexes.rb
20250103000000_add_workflow_indexes.rb
20250104000000_change_company_index.rb
...
```

Replaying every migration becomes increasingly expensive for fresh installations.

ActiveRecord solves this problem with:

```text id="tyk4i6"
db/schema.rb
```

which represents the current database state independently from migration history.

CouchbaseORM should provide the same capability for indexes.

---

# Goals

* Provide a snapshot of the current index schema.
* Speed up fresh installations.
* Preserve migration history.
* Stay close to ActiveRecord.
* Keep migrations as the source of truth.

---

# Non-Goals

* Rewriting migration history.
* Automatic compaction.
* Comparing against `system:indexes`.
* Removing old migrations.
* Replacing index migrations.

---

# Commands

## Dump schema

```bash id="wxwklv"
bundle exec couchbaseorm index:schema:dump
```

Generates:

```text id="pjwdix"
db/index_schema.rb
```

---

## Load schema

```bash id="l6tkhg"
bundle exec couchbaseorm index:schema:load
```

Loads all indexes defined in:

```text id="7jbv5k"
db/index_schema.rb
```

without replaying historical migrations.

---

# Schema File

Default location:

```text id="17oqyj"
db/index_schema.rb
```

Example:

```ruby id="qj5dvf"
CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
  add_index :type_company,
    keys: [:type, :company_id],
    where: "type is valued and company_id is valued"

  add_index :date_on_type,
    keys: [:date]

  add_index :workflow_by_company,
    keys: [:company_id],
    where: "type = 'workflow'"
end
```

---

# Schema Version

The schema stores the latest migration version:

```ruby id="u22owj"
version: 2026_01_01_120000
```

similar to:

```ruby id="u6lbwy"
ActiveRecord::Schema.define(version: ...)
```

---

# IndexSchema DSL

Introduce:

```ruby id="b4obva"
CouchbaseOrm::IndexSchema
```

Example:

```ruby id="r9snbn"
CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
  add_index :type_company,
    keys: [:type, :company_id]

  add_index :date_on_type,
    keys: [:date]
end
```

The DSL supports:

```ruby id="j9n2g9"
add_index
```

---

# Schema Dump

## Behavior

`index:schema:dump`:

1. Loads all migrations.
2. Replays them in memory.
3. Computes the final schema.
4. Generates:

```text id="pdikzq"
db/index_schema.rb
```

The generated schema contains only indexes that currently exist.

Intermediate operations are discarded.

---

## Example

Migrations:

```ruby id="5gohgq"
add_index :type_company,
  keys: [:company_id, :type]

remove_index :type_company

add_index :type_company,
  keys: [:type, :company_id]
```

Generated schema:

```ruby id="95nr5m"
CouchbaseOrm::IndexSchema.define(version: 2026_01_01_120000) do
  add_index :type_company,
    keys: [:type, :company_id]
end
```

---

# Schema Load

## Behavior

`index:schema:load`:

1. Loads:

```text id="k0myly"
db/index_schema.rb
```

2. Executes:

```ruby id="a6n8vc"
add_index
```

operations.

3. Builds the indexes.

No migration files are replayed.

---

# Build Behavior

Indexes with:

```ruby id="gx9sx2"
defer_build: true
```

are collected and built together:

```ruby id="uwv48h"
build_indexes(
  :type_company,
  :date_on_type
)
```

This behavior is internal to schema loading.

---

# Internal Representation

Introduce:

```ruby id="sq97sj"
CouchbaseOrm::IndexSchema::Definition
```

Responsibilities:

```ruby id="x9h4da"
add_index
remove_index
rename_index
```

Example:

```ruby id="zn4wbm"
definition.indexes
```

returns:

```ruby id="cjlwm6"
{
  type_company: {
    keys: [:type, :company_id]
  },

  date_on_type: {
    keys: [:date]
  }
}
```

---

# Supported Operations

Schema dump understands:

```ruby id="9j1tyk"
add_index
remove_index
rename_index
```

and preserves:

```ruby id="13vmb7"
keys
where
num_replica
defer_build
```

---

# Unsupported Operations

Schema dump ignores:

```ruby id="cc0m9x"
build_indexes
```

because build operations are runtime concerns and do not affect schema state.

---

# Relationship with Migrations

Migrations remain the source of truth.

The schema file is a snapshot.

Like ActiveRecord:

```text id="b5pp4d"
db/indexes/
```

contains history.

```text id="vsl7cx"
db/index_schema.rb
```

contains the current state.

---

# Acceptance Criteria

### Dump

Given:

```ruby id="rnxg8c"
add_index :type_company,
  keys: [:company_id, :type]

remove_index :type_company

add_index :type_company,
  keys: [:type, :company_id]
```

Then:

```text id="n9tn7l"
db/index_schema.rb
```

contains:

```ruby id="h6cbg7"
add_index :type_company,
  keys: [:type, :company_id]
```

and no intermediate operations.

---

### Load

Given:

```text id="t8p3l0"
db/index_schema.rb
```

Then:

```bash id="k2gszk"
bundle exec couchbaseorm index:schema:load
```

creates the indexes without replaying migration files.

---

# Future Extensions

Possible future additions:

* `index:schema:load:if_empty`
* support for scopes and collections
* `index:schema:dump --dry-run`
* `index:schema:diff`
* support for comments and metadata

The design intentionally mirrors ActiveRecord's `schema.rb` and `db:schema:load` philosophy.
